### PR TITLE
add check to comment out bAcceptSyncInfo parameter in file ti_radio_c…

### DIFF
--- a/fw/makefile
+++ b/fw/makefile
@@ -170,6 +170,10 @@ ti_radio_config.c ti_drivers_config.c ti_devices_config.c ti_radio_config.h ti_d
 syscfg: sniffle.syscfg
 	@ echo Generating configuration files...
 	@ $(SYSCONFIG_TOOL) --board $(SYSCFG_BOARD) --rtos tirtos --compiler gcc --product $(SIMPLELINK_SDK_INSTALL_DIR)/.metadata/product.json --output $(@D) $<
+ifneq ($(filter $(PLATFORM), $(CC2651P3_PLATFORMS)),)
+	@ echo Modifying ti_radio_config.c to remove bAcceptSyncInfo line \(CC2651P3 only\)
+	@ sed -i "s/.extFilterConfig.bAcceptSyncInfo = 0x0,*/\/\/.extFilterConfig.bAcceptSyncInfo = 0x0,/g" ti_radio_config.c
+endif
 
 %.obj: %.c $(CONFIGPKG)/compiler.opt syscfg
 	@ echo Building $@


### PR DESCRIPTION
Add `makefile` check for the `CC2651P3` platform to comment out the bAcceptSyncInfo parameter.

Reference:
https://e2e.ti.com/support/wireless-connectivity/bluetooth-group/bluetooth/f/bluetooth-forum/1090449/cc2651p3-sysconfig-including-bacceptsyncinfo-parameter-for-cmd_ble5_scanner

This allows users to run the command:
`make PLATFORM=CC2651P31` to build `sniffle.out`

