### PR TITLE
Fixed typo in info log message for starting of control thread

### DIFF
--- a/python_cli/sniffle_extcap.py
+++ b/python_cli/sniffle_extcap.py
@@ -458,7 +458,7 @@ class SniffleExtcapPlugin():
 
         if self.controlReadStream:
             # start a thread to read control messages
-            self.logger.info('Staring control thread')
+            self.logger.info('Starting control thread')
             self.controlThread = threading.Thread(target=self.controlThreadMain, daemon=True)
             self.controlThread.start()
 


### PR DESCRIPTION
Was missing a "t" in "Starting control thread" info log message.